### PR TITLE
feat(server): complete discoverability, add getdatavalues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rasn = "0.18"
 hex = "0.4.3"
-mms = { git = "https://github.com/OpenEnergyStack/iso9506-mms" }
+mms = { path = "../../OpenEnergyStack/iso9506-mms" }
 async-trait = "0.1"
 chrono = "0.4"
 tokio = { version = "1", features = ["sync", "rt", "macros", "time", "net"] }

--- a/src/client/client_builder.rs
+++ b/src/client/client_builder.rs
@@ -18,6 +18,7 @@ pub(crate) trait Transport: Send + Sync {
     async fn get_server_directory(&self) -> Result<Vec<String>, Error>;
     async fn get_logical_device_directory(&self, ld_name: String) -> Result<Vec<String>, Error>;
     async fn get_data_definition(&self, data_ref: DataReference) -> Result<DataDefinition, Error>;
+    async fn get_data_set_directory(&self, data_set_ref: String) -> Result<Vec<String>, Error>;
     async fn set_brcb_values(
         &self,
         brcb_ref: String,
@@ -125,6 +126,10 @@ impl Client {
         data_ref: DataReference,
     ) -> Result<DataDefinition, Error> {
         self.transport.get_data_definition(data_ref).await
+    }
+
+    pub async fn get_data_set_directory(&self, data_set_ref: String) -> Result<Vec<String>, Error> {
+        self.transport.get_data_set_directory(data_set_ref).await
     }
 
     pub async fn set_brcb_values(
@@ -237,6 +242,14 @@ mod tests {
                 .unwrap()
                 .push(format!("def:{}", data_ref.reference));
             todo!("Return proper DataDefinition")
+        }
+
+        async fn get_data_set_directory(&self, data_set_ref: String) -> Result<Vec<String>, Error> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("ds:{}", data_set_ref));
+            Ok(vec![])
         }
 
         async fn set_brcb_values(

--- a/src/client/mms.rs
+++ b/src/client/mms.rs
@@ -487,11 +487,15 @@ fn parse_references(
 }
 
 fn parse_paths(data_reference: &DataReference) -> Result<(String, Vec<&str>), Error> {
-    let parts: Vec<&str> = data_reference.reference.split('/').collect();
+    parse_reference(&data_reference.reference)
+}
+
+fn parse_reference(reference: &str) -> Result<(String, Vec<&str>), Error> {
+    let parts: Vec<&str> = reference.split('/').collect();
     if parts.len() != 2 {
         return Err(Error::ParseError(format!(
             "Invalid reference format. Expected 'Domain/Path[FC]', found: {}",
-            data_reference.reference
+            reference
         )));
     }
 
@@ -499,6 +503,94 @@ fn parse_paths(data_reference: &DataReference) -> Result<(String, Vec<&str>), Er
     let data_path = parts[1].split('.').collect::<Vec<&str>>();
 
     Ok((domain_id, data_path))
+}
+
+/// Builds an MMS `ObjectName` for a DataSet reference.
+///
+/// IEC 61850 DataSet references have the form `IEDLD/LN.DataSetName`.
+/// The logical device (`IEDLD`) becomes the MMS domain-id. The logical node
+/// and data set name are encoded as `LN$DataSetName` in the MMS itemId.
+///
+/// When the reference contains only a logical device (e.g. `IEDLD`), the
+/// object name is `vmd-specific` so that `GetDataSetDirectory` returns all
+/// DataSets for that LD.
+fn build_data_set_object_name(data_set_ref: &str) -> Result<ObjectName, Error> {
+    // LD-only references such as `IEDLD` are sent as vmd-specific object names.
+    if !data_set_ref.contains('/') {
+        return Ok(ObjectName::vmd_specific(Identifier(
+            VisibleString::try_from(data_set_ref.to_string()).unwrap_or_default(),
+        )));
+    }
+
+    let (domain_id, data_path) = parse_reference(data_set_ref)?;
+
+    if data_path.len() == 1 {
+        // Reference stops at the LN (e.g. `IEDLD/LLN0`).
+        return Ok(ObjectName::domain_specific(ObjectNameDomainSpecific {
+            domain_id: Identifier(VisibleString::try_from(domain_id).unwrap_or_default()),
+            item_id: Identifier(
+                VisibleString::try_from(data_path[0].to_string()).unwrap_or_default(),
+            ),
+        }));
+    }
+
+    let item_id = data_path.join("$");
+    Ok(ObjectName::domain_specific(ObjectNameDomainSpecific {
+        domain_id: Identifier(VisibleString::try_from(domain_id).unwrap_or_default()),
+        item_id: Identifier(VisibleString::try_from(item_id).unwrap_or_default()),
+    }))
+}
+
+/// Converts an MMS `VariableAccessSpecification` returned by
+/// `GetNamedVariableListAttributes` into an IEC 61850 DataSet member reference
+/// of the form `IEDLD/LN.DataSetName`.
+fn variable_access_specification_to_data_set_ref(
+    spec: &VariableSpecification,
+) -> Result<String, Error> {
+    let VariableSpecification::name(name) = spec else {
+        return Err(Error::ParseError(
+            "unsupported variable specification for data set member".to_string(),
+        ));
+    };
+
+    match name {
+        ObjectName::domain_specific(ds) => {
+            let item_id = ds.item_id.0.to_string();
+            let parts: Vec<&str> = item_id.split('$').collect();
+            if parts.len() < 2 {
+                return Err(Error::ParseError(format!(
+                    "invalid domain-specific data set item id: {}",
+                    item_id
+                )));
+            }
+            let ln = parts[0];
+            let data_set_name = parts[1];
+            Ok(format!("{}/{ln}.{data_set_name}", ds.domain_id.0))
+        }
+        ObjectName::vmd_specific(id) => {
+            let item_id = id.0.to_string();
+            let parts: Vec<&str> = item_id.split('$').collect();
+            if parts.len() < 2 {
+                return Err(Error::ParseError(format!(
+                    "invalid vmd-specific data set item id: {}",
+                    item_id
+                )));
+            }
+            let ld = parts[0];
+            let ln = parts[1];
+            let data_set_name = parts.get(2).unwrap_or(&"");
+            if data_set_name.is_empty() {
+                return Err(Error::ParseError(format!(
+                    "invalid vmd-specific data set item id: {}",
+                    item_id
+                )));
+            }
+            Ok(format!("{ld}/{ln}.{data_set_name}"))
+        }
+        ObjectName::aa_specific(_) => Err(Error::ParseError(
+            "aa-specific object names are not supported for data sets".to_string(),
+        )),
+    }
 }
 
 // return itemId for a given reference, e.g., "IED1/LLN0$ST$Val" -> "LLN0$ST$Val"
@@ -515,6 +607,19 @@ fn build_item_id(fc: &str, item_id_path: Vec<&str>) -> String {
         item_id.push_str(part);
     }
 
+    item_id
+}
+
+/// Builds an itemId for `GetVariableAccessAttributes` where no MMS alternate
+/// access is available. Array indices are kept in the path, e.g.
+/// `LLN0$ST$Hrs$hr(1)`.
+fn build_item_id_for_definition(fc: &str, item_id_path: Vec<&str>) -> String {
+    let logical_node = item_id_path[0];
+    let mut item_id = format!("{}${}", logical_node, fc);
+    for part in &item_id_path[1..] {
+        item_id.push('$');
+        item_id.push_str(part);
+    }
     item_id
 }
 
@@ -891,14 +996,23 @@ async fn subscribe_last_appl_error(
 /// Returns `true` when `spec` identifies a `LastApplError` information report.
 fn is_last_app_error_report(spec: &VariableAccessSpecification) -> bool {
     fn is_last_appl_error_name(name: &ObjectName) -> bool {
-        matches!(name, ObjectName::vmd_specific(id) if id.0.to_string() == "LastApplError")
+        match name {
+            ObjectName::vmd_specific(id) => id.0.to_string() == "LastApplError",
+            _ => false,
+        }
     }
+
     match spec {
         VariableAccessSpecification::variableListName(name) => is_last_appl_error_name(name),
         VariableAccessSpecification::listOfVariable(list) => {
-            list.0.len() == 1
-                && matches!(&list.0[0].variable_specification,
-                    VariableSpecification::name(n) if is_last_appl_error_name(n))
+            if list.0.len() == 1 {
+                match &list.0[0].variable_specification {
+                    VariableSpecification::name(n) => is_last_appl_error_name(n),
+                    _ => false,
+                }
+            } else {
+                false
+            }
         }
     }
 }
@@ -1053,7 +1167,8 @@ impl Transport for MmsTransport {
         let domain_object = ObjectNameDomainSpecific {
             domain_id: Identifier(VisibleString::try_from(domain_id).unwrap_or_default()),
             item_id: Identifier(
-                VisibleString::try_from(build_item_id(fc, data_path.clone())).unwrap_or_default(),
+                VisibleString::try_from(build_item_id_for_definition(fc, data_path.clone()))
+                    .unwrap_or_default(),
             ),
         };
         let object_name = ObjectName::domain_specific(domain_object);
@@ -1070,6 +1185,25 @@ impl Transport for MmsTransport {
             name,
             &result.type_description,
         ))
+    }
+
+    async fn get_data_set_directory(&self, data_set_ref: String) -> Result<Vec<String>, Error> {
+        let object_name = build_data_set_object_name(&data_set_ref)?;
+
+        let response = self
+            .client
+            .get_named_variable_list_attributes(object_name)
+            .await
+            .map_err(|e| Error::ConnectionFailed(e.to_string()))?;
+
+        response
+            .list_of_variable
+            .0
+            .into_iter()
+            .map(|entry| {
+                variable_access_specification_to_data_set_ref(&entry.variable_specification)
+            })
+            .collect()
     }
 
     async fn set_brcb_values(
@@ -2118,22 +2252,20 @@ mod tests {
     use rasn::types::{OctetString, SequenceOf};
 
     fn unwrap_item_id(spec: &VariableAccessSpecification) -> String {
-        match spec {
-            VariableAccessSpecification::listOfVariable(list) => {
-                let first = list.0.get(0).expect("expected at least one variable");
-
-                match &first.variable_specification {
-                    VariableSpecification::name(object_name) => {
-                        if let ObjectName::domain_specific(ds) = object_name {
-                            return ds.item_id.0.to_string();
-                        }
-                        panic!("unexpected object name variant");
-                    }
-                    _ => panic!("unexpected variable specification variant"),
-                }
-            }
+        let list = match spec {
+            VariableAccessSpecification::listOfVariable(list) => list,
             _ => panic!("unexpected variable access spec variant"),
-        }
+        };
+        let first = list.0.get(0).expect("expected at least one variable");
+        let object_name = match &first.variable_specification {
+            VariableSpecification::name(object_name) => object_name,
+            _ => panic!("unexpected variable specification variant"),
+        };
+        let ds = match object_name {
+            ObjectName::domain_specific(ds) => ds,
+            _ => panic!("unexpected object name variant"),
+        };
+        ds.item_id.0.to_string()
     }
 
     #[test]
@@ -2337,5 +2469,80 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn build_item_id_for_definition_keeps_full_path() {
+        let path = vec!["LLN0", "Mod", "stVal"];
+        assert_eq!(
+            build_item_id_for_definition("ST", path),
+            "LLN0$ST$Mod$stVal"
+        );
+    }
+
+    #[test]
+    fn build_item_id_for_definition_keeps_array_index() {
+        let path = vec!["LLN0", "Hrs", "hr(3)"];
+        assert_eq!(
+            build_item_id_for_definition("ST", path),
+            "LLN0$ST$Hrs$hr(3)"
+        );
+    }
+
+    #[test]
+    fn build_data_set_object_name_uses_vmd_specific_for_ld_only() {
+        let name = build_data_set_object_name("IED1LD0").expect("valid ld reference");
+        assert!(matches!(name, ObjectName::vmd_specific(id) if id.0.to_string() == "IED1LD0"));
+    }
+
+    #[test]
+    fn build_data_set_object_name_uses_domain_specific_for_ln() {
+        let name = build_data_set_object_name("IED1LD0/LLN0").expect("valid ln reference");
+        match name {
+            ObjectName::domain_specific(ds) => {
+                assert_eq!(ds.domain_id.0.to_string(), "IED1LD0");
+                assert_eq!(ds.item_id.0.to_string(), "LLN0");
+            }
+            other => panic!("expected domain-specific object name, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn build_data_set_object_name_uses_domain_specific_for_full_data_set() {
+        let name =
+            build_data_set_object_name("IED1LD0/LLN0.dataSet1").expect("valid data set reference");
+        match name {
+            ObjectName::domain_specific(ds) => {
+                assert_eq!(ds.domain_id.0.to_string(), "IED1LD0");
+                assert_eq!(ds.item_id.0.to_string(), "LLN0$dataSet1");
+            }
+            other => panic!("expected domain-specific object name, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn data_set_ref_from_domain_specific_variable_specification() {
+        let spec =
+            VariableSpecification::name(ObjectName::domain_specific(ObjectNameDomainSpecific {
+                domain_id: Identifier(VisibleString::try_from("IED1LD0").unwrap()),
+                item_id: Identifier(VisibleString::try_from("LLN0$dataSet1").unwrap()),
+            }));
+
+        assert_eq!(
+            variable_access_specification_to_data_set_ref(&spec).expect("valid spec"),
+            "IED1LD0/LLN0.dataSet1"
+        );
+    }
+
+    #[test]
+    fn data_set_ref_from_vmd_specific_variable_specification() {
+        let spec = VariableSpecification::name(ObjectName::vmd_specific(Identifier(
+            VisibleString::try_from("IED1LD0$LLN0$dataSet1").unwrap(),
+        )));
+
+        assert_eq!(
+            variable_access_specification_to_data_set_ref(&spec).expect("valid spec"),
+            "IED1LD0/LLN0.dataSet1"
+        );
     }
 }

--- a/src/server/data_value_store.rs
+++ b/src/server/data_value_store.rs
@@ -1,0 +1,166 @@
+//! Runtime store for IEC 61850 DataAttribute values.
+//!
+//! The store is keyed by [`DataRef`], which currently is a path string. The model
+//! assigns a stable [`DataRef`] to every leaf DataAttribute when it is loaded.
+//! Future extensions can add token-based interning without changing callers.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use crate::server::types::DataValue;
+
+/// Errors that can occur when accessing the value store.
+#[derive(Debug)]
+pub enum StoreError {
+    UnknownRef(DataRef),
+}
+
+impl std::fmt::Display for StoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownRef(r) => write!(f, "Unknown data reference: {}", r.0),
+        }
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+/// Stable reference to a leaf DataAttribute.
+///
+/// Today this is the full IEC 61850 path (`LD0/MMXU1.A.phsA.cVal.mag.f`).
+/// It is intentionally cheap to clone as an `Arc<str>` if paths become long,
+/// but `String` keeps the first iteration simple.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DataRef(pub String);
+
+impl DataRef {
+    /// Creates a new reference from an owned or borrowed path.
+    pub fn new(path: impl Into<String>) -> Self {
+        Self(path.into())
+    }
+}
+
+impl AsRef<str> for DataRef {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A live value cell for one leaf DataAttribute.
+///
+/// Each cell holds exactly one IEC 61850 DataValue. Timestamp and quality
+/// are not stored here; in the model they are separate leaf DAs such as `t`
+/// and `q` within the same CDC.
+pub struct ValueCell {
+    value: RwLock<DataValue>,
+}
+
+impl ValueCell {
+    fn new(initial: DataValue) -> Self {
+        Self {
+            value: RwLock::new(initial),
+        }
+    }
+
+    /// Reads the current value.
+    pub fn read(&self) -> DataValue {
+        self.value.read().clone()
+    }
+
+    /// Overwrites the current value.
+    pub fn write(&self, value: DataValue) {
+        *self.value.write() = value;
+    }
+}
+
+/// Central runtime store for all leaf DataAttribute values.
+///
+/// The store is cheaply cloneable because it holds its data behind an `Arc`,
+/// allowing it to be shared between the model, the MMS server task, and
+/// real-time update loops.
+#[derive(Default, Clone)]
+pub struct LeafDataStore {
+    inner: Arc<DataValueStoreInner>,
+}
+
+#[derive(Default)]
+struct DataValueStoreInner {
+    cells: RwLock<HashMap<DataRef, ValueCell>>,
+}
+
+impl LeafDataStore {
+    /// Creates an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// If the path already exists, the existing cell is left unchanged.
+    pub fn register(&self, reference: DataRef, initial: DataValue) {
+        let mut cells = self.inner.cells.write();
+        cells
+            .entry(reference)
+            .or_insert_with(|| ValueCell::new(initial));
+    }
+
+    /// Returns the current value of a leaf attribute, if it exists.
+    pub fn read(&self, reference: &DataRef) -> Result<DataValue, StoreError> {
+        let cells = self.inner.cells.read();
+        cells
+            .get(reference)
+            .map(|cell| cell.read())
+            .ok_or_else(|| StoreError::UnknownRef(reference.clone()))
+    }
+
+    /// Overwrites the value of a leaf attribute.
+    pub fn write(&self, reference: &DataRef, value: DataValue) -> Result<(), StoreError> {
+        let cells = self.inner.cells.read();
+        let cell = cells
+            .get(reference)
+            .ok_or_else(|| StoreError::UnknownRef(reference.clone()))?;
+        cell.write(value);
+        Ok(())
+    }
+
+    /// Returns a cloned copy of all registered references.
+    pub fn references(&self) -> Vec<DataRef> {
+        self.inner.cells.read().keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_write_roundtrip() {
+        let store = LeafDataStore::new();
+        let reference = DataRef::new("LD0/LLN0.NamPlt.vendor");
+
+        store.register(reference.clone(), DataValue::Bool(false));
+        assert!(matches!(
+            store.read(&reference).unwrap(),
+            DataValue::Bool(false)
+        ));
+
+        store
+            .write(
+                &reference,
+                DataValue::VisibleString("OpenEnergyStack".to_string()),
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.read(&reference).unwrap(),
+            DataValue::VisibleString("OpenEnergyStack".to_string())
+        );
+    }
+
+    #[test]
+    fn unknown_reference_returns_error() {
+        let store = LeafDataStore::new();
+        let reference = DataRef::new("LD0/LLN0.NamPlt.vendor");
+        assert!(store.read(&reference).is_err());
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,8 +1,13 @@
 //! IEC 61850 server — data model and network services.
 
+pub mod data_value_store;
 mod model;
 #[allow(clippy::module_inception)]
 mod server;
 pub(crate) mod server_mms_mapping;
+pub mod types;
 
+pub use data_value_store::{DataRef, LeafDataStore};
+pub use model::ServerModel;
 pub use server::{Association, AssociationId, AssociationMap, Mapping, Server, ServerTlsConfig};
+pub use types::DataValue;

--- a/src/server/model.rs
+++ b/src/server/model.rs
@@ -1,4 +1,85 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use serde::Deserialize;
+
+use crate::server::data_value_store::{DataRef, LeafDataStore};
+use crate::server::types::DataValue;
+use crate::types::{DataDefinition, DataType, Quality, TimeQuality, Timestamp};
+
+/// A single step in a parsed IEC 61850 model path.
+#[derive(Debug, Clone)]
+enum PathStep {
+    Component(String),
+    Index(u32),
+}
+
+/// Parse a dot-separated path that may contain array indices in parentheses.
+fn parse_model_path(path: &str) -> Vec<PathStep> {
+    let mut steps = Vec::new();
+    let mut current = String::new();
+    let mut chars = path.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '.' => {
+                if !current.is_empty() {
+                    steps.push(PathStep::Component(current));
+                    current = String::new();
+                }
+            }
+            '(' => {
+                if !current.is_empty() {
+                    steps.push(PathStep::Component(current));
+                    current = String::new();
+                }
+                let mut idx = String::new();
+                for c in chars.by_ref() {
+                    if c == ')' {
+                        break;
+                    }
+                    idx.push(c);
+                }
+                if let Ok(parsed) = idx.parse::<u32>() {
+                    steps.push(PathStep::Index(parsed));
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if !current.is_empty() {
+        steps.push(PathStep::Component(current));
+    }
+
+    steps
+}
+
+/// Apply an array index to a value, then any remaining path steps.
+fn apply_index_to_value(value: &DataValue, idx: u32, remaining: &[PathStep]) -> Option<DataValue> {
+    match value {
+        DataValue::Array(arr) => {
+            let elem = arr.get(idx as usize)?.clone();
+            apply_value_steps(&elem, remaining)
+        }
+        _ => None,
+    }
+}
+
+/// Apply remaining path steps to a plain runtime value.
+fn apply_value_steps(value: &DataValue, steps: &[PathStep]) -> Option<DataValue> {
+    match steps.first() {
+        None => Some(value.clone()),
+        Some(PathStep::Index(idx)) => match value {
+            DataValue::Array(arr) => {
+                let elem = arr.get(*idx as usize)?.clone();
+                apply_value_steps(&elem, &steps[1..])
+            }
+            _ => None,
+        },
+        Some(PathStep::Component(_)) => None,
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct CompiledIedConfig {
@@ -30,26 +111,48 @@ struct CompiledLogicalNode {
     data_objects: Vec<CompiledDataObject>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 struct CompiledDataObject {
     name: String,
+    /// Array size from SCL (`count`). `0` or missing means a single object.
+    #[serde(default)]
+    count: u32,
     #[serde(default)]
     children: Vec<CompiledDataObjectChild>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(tag = "type")]
 enum CompiledDataObjectChild {
     Attribute(CompiledDataAttribute),
     SubObject(CompiledDataObject),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 struct CompiledDataAttribute {
     name: String,
     fc: FunctionalConstraint,
+    /// Array size from SCL (`count`). `0` or missing means a single attribute.
+    #[serde(default)]
+    count: u32,
+    /// Leaf attribute type. When `da_type` is missing for a leaf (no children)
+    /// an error is reported so that the model cannot load with an untyped leaf.
+    #[serde(rename = "da_type")]
+    attribute_type: Option<AttributeType>,
     #[serde(default)]
     children: Vec<CompiledDataAttribute>,
+}
+
+/// IEC 61850 leaf data attribute type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttributeType {
+    Bool,
+    Int32,
+    Float32,
+    Quality,
+    Timestamp,
+    VisibleString,
 }
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
@@ -58,6 +161,10 @@ struct CompiledDataAttribute {
 pub enum ModelLoadError {
     Io(std::io::Error),
     Json(serde_json::Error),
+    /// A data attribute lacks the required `da_type` field.
+    MissingAttributeType {
+        path: String,
+    },
 }
 
 impl std::fmt::Display for ModelLoadError {
@@ -65,6 +172,9 @@ impl std::fmt::Display for ModelLoadError {
         match self {
             Self::Io(e) => write!(f, "Failed to read model file: {e}"),
             Self::Json(e) => write!(f, "Failed to parse model JSON: {e}"),
+            Self::MissingAttributeType { path } => {
+                write!(f, "Missing 'da_type' for leaf data attribute at {path}")
+            }
         }
     }
 }
@@ -125,24 +235,151 @@ impl FunctionalConstraint {
             Self::CO => "CO",
         }
     }
+
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "ST" => Some(Self::ST),
+            "MX" => Some(Self::MX),
+            "SP" => Some(Self::SP),
+            "SE" => Some(Self::SE),
+            "SF" => Some(Self::SF),
+            "CF" => Some(Self::CF),
+            "DC" => Some(Self::DC),
+            "EX" => Some(Self::EX),
+            "BR" => Some(Self::BR),
+            "RP" => Some(Self::RP),
+            "LG" => Some(Self::LG),
+            "GO" => Some(Self::GO),
+            "SV" => Some(Self::SV),
+            "TI" => Some(Self::TI),
+            "IN" => Some(Self::IN),
+            "CO" => Some(Self::CO),
+            _ => None,
+        }
+    }
 }
 
 /// A Data Attribute node in the structural tree.
 ///
-/// For struct-typed DAs (e.g. `cVal` of type `Vector`) the `children` list
-/// contains the BDA sub-attributes. For leaf DAs, `children` is empty.
+/// A DA is either a structural node that contains sub-attributes (e.g. `cVal`
+/// of type `Vector`), a leaf node that maps to a value cell in the runtime
+/// store, or an array of either of those. These cases are mutually exclusive.
 #[derive(Debug, Clone)]
-pub struct DataAttributeNode {
-    pub name: String,
-    pub fc: FunctionalConstraint,
-    pub children: Vec<DataAttributeNode>,
+pub enum DataAttributeNode {
+    /// A leaf DataAttribute backed by a value cell in [`ServerModel::value_store`].
+    Leaf {
+        name: String,
+        fc: FunctionalConstraint,
+        reference: DataRef,
+        attribute_type: Option<AttributeType>,
+    },
+    /// A structural DataAttribute that contains nested Basic Data Attributes.
+    Struct {
+        name: String,
+        fc: FunctionalConstraint,
+        children: Vec<DataAttributeNode>,
+    },
+    /// A homogeneous array of DataAttributes.
+    Array {
+        name: String,
+        fc: FunctionalConstraint,
+        count: u32,
+        elements: Vec<DataAttributeNode>,
+    },
 }
 
-/// A child of a Data Object — either a leaf DA or a Sub-Data Object.
+impl DataAttributeNode {
+    /// Returns the name of this DataAttribute.
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Leaf { name, .. } | Self::Struct { name, .. } | Self::Array { name, .. } => name,
+        }
+    }
+
+    /// Returns the functional constraint of this DataAttribute.
+    pub fn fc(&self) -> FunctionalConstraint {
+        match self {
+            Self::Leaf { fc, .. } | Self::Struct { fc, .. } | Self::Array { fc, .. } => *fc,
+        }
+    }
+
+    /// Reads this DataAttribute as a value.
+    ///
+    /// For leaf attributes the value is read from the runtime store. For
+    /// structural attributes a `DataValue::Struct` is built recursively from
+    /// the child attributes. For arrays a `DataValue::Array` is built from the
+    /// element attributes.
+    pub fn read_values(&self, store: &LeafDataStore) -> Option<DataValue> {
+        match self {
+            Self::Leaf { reference, .. } => store.read(reference).ok(),
+            Self::Struct { children, .. } => {
+                let fields: Vec<DataValue> = children
+                    .iter()
+                    .map(|child| child.read_values(store))
+                    .collect::<Option<Vec<_>>>()?;
+                Some(DataValue::Struct(Arc::new(fields)))
+            }
+            Self::Array { elements, .. } => {
+                let values: Vec<DataValue> = elements
+                    .iter()
+                    .map(|elem| elem.read_values(store))
+                    .collect::<Option<Vec<_>>>()?;
+                Some(DataValue::Array(Arc::new(values)))
+            }
+        }
+    }
+}
+
+/// A child of a Data Object — a DA, a Sub-Data Object, or an array of either.
 #[derive(Debug, Clone)]
 pub enum DataObjectChild {
     Attribute(DataAttributeNode),
     SubObject(DataObjectNode),
+    /// A homogeneous array of DataAttributes.
+    AttributeArray {
+        name: String,
+        fc: FunctionalConstraint,
+        count: u32,
+        elements: Vec<DataAttributeNode>,
+    },
+    /// A homogeneous array of Sub-Data Objects.
+    SubObjectArray {
+        name: String,
+        count: u32,
+        elements: Vec<DataObjectNode>,
+    },
+}
+
+impl DataObjectChild {
+    /// Reads the value of this child.
+    pub fn read_values(&self, store: &LeafDataStore) -> Option<DataValue> {
+        match self {
+            DataObjectChild::Attribute(da) => da.read_values(store),
+            DataObjectChild::SubObject(sdo) => sdo.read_values(store),
+            DataObjectChild::AttributeArray { elements, .. } => {
+                let values: Vec<DataValue> = elements
+                    .iter()
+                    .map(|elem| elem.read_values(store))
+                    .collect::<Option<Vec<_>>>()?;
+                Some(DataValue::Array(Arc::new(values)))
+            }
+            DataObjectChild::SubObjectArray { elements, .. } => {
+                let values: Vec<DataValue> = elements
+                    .iter()
+                    .map(|elem| elem.read_values(store))
+                    .collect::<Option<Vec<_>>>()?;
+                Some(DataValue::Array(Arc::new(values)))
+            }
+        }
+    }
+
+    /// Looks up a nested DataObject child by name.
+    pub fn as_sub_object(&self) -> Option<&DataObjectNode> {
+        match self {
+            DataObjectChild::SubObject(sdo) => Some(sdo),
+            _ => None,
+        }
+    }
 }
 
 /// A Data Object node in the structural tree.
@@ -152,13 +389,42 @@ pub struct DataObjectNode {
     pub children: Vec<DataObjectChild>,
 }
 
+impl DataObjectNode {
+    /// Looks up an immediate child by name.
+    pub fn find_child(&self, name: &str) -> Option<&DataObjectChild> {
+        self.children.iter().find(|child| match child {
+            DataObjectChild::Attribute(da) => da.name() == name,
+            DataObjectChild::SubObject(sdo) => sdo.name == name,
+            DataObjectChild::AttributeArray { name: n, .. } => n == name,
+            DataObjectChild::SubObjectArray { name: n, .. } => n == name,
+        })
+    }
+
+    /// Reads the values of all leaf DAs under this DataObject as a structure.
+    pub fn read_values(&self, store: &LeafDataStore) -> Option<DataValue> {
+        let fields: Vec<DataValue> = self
+            .children
+            .iter()
+            .map(|child| child.read_values(store))
+            .collect::<Option<Vec<_>>>()?;
+        Some(DataValue::Struct(Arc::new(fields)))
+    }
+}
+
 /// A Logical Node in the structural tree.
 #[derive(Debug, Clone)]
 pub struct LogicalNodeNode {
     pub ln_class: String,
     pub inst: String,
-    pub prefix: String,
+    pub ln_prefix: String,
     pub data_objects: Vec<DataObjectNode>,
+}
+
+impl LogicalNodeNode {
+    /// Looks up an immediate child DataObject by name.
+    pub fn find_data_object(&self, name: &str) -> Option<&DataObjectNode> {
+        self.data_objects.iter().find(|do_| do_.name == name)
+    }
 }
 
 /// A Logical Device in the structural tree.
@@ -180,19 +446,442 @@ pub struct ServerModel {
     pub ied_name: String,
     pub config: IedConfig,
     pub logical_devices: Vec<LogicalDeviceNode>,
+    /// Runtime value store for every leaf DataAttribute.
+    pub value_store: LeafDataStore,
+    /// Maps a DataAttribute [`DataRef`] back to its full IEC 61850 path.
+    /// Useful for diagnostics and for external RT functions that discover
+    /// references at runtime.
+    pub reference_to_path: HashMap<DataRef, String>,
 }
 
 impl ServerModel {
+    /// Looks up a Logical Node by its path segment within a Logical Device.
+    ///
+    /// `ln_name` is the full LN name as used in MMS item IDs, e.g. `LLN0` or
+    /// `Pref_MMXU1`.
+    pub fn find_logical_node(&self, ld_inst: &str, ln_name: &str) -> Option<&LogicalNodeNode> {
+        let ld = self.logical_devices.iter().find(|ld| ld.inst == ld_inst)?;
+        ld.logical_nodes.iter().find(|ln| {
+            let expected = format!("{}{}{}", ln.ln_prefix, ln.ln_class, ln.inst);
+            expected == ln_name
+        })
+    }
+
+    /// Reads the value at a model path.
+    ///
+    /// The path uses the internal model notation:
+    /// `{ied_name}{ld_inst}/{ln_name}.{do_name}[.{child_name}]*`
+    ///
+    /// An optional trailing `[FC]` (as produced by the MMS mapping) is ignored;
+    /// the functional constraint is resolved from the model itself.
+    ///
+    /// Array indices may be embedded using parentheses, e.g.
+    /// `{ied_name}{ld_inst}/{ln_name}.HA.phsAHar(7).cVal.mag.f`.
+    ///
+    /// The path may target a leaf DataAttribute, a structured DataAttribute, an
+    /// array, or a DataObject/SubDataObject. In the latter cases the result is a
+    /// `DataValue::Struct` or `DataValue::Array` built from the leaf values.
+    pub fn read_by_path(&self, path: &str) -> Option<DataValue> {
+        let (domain, rest) = path.split_once('/')?;
+        let ld_inst = domain.strip_prefix(&self.ied_name).unwrap_or(domain);
+
+        // The MMS mapping may append a trailing `[FC]`; capture it if present.
+        let rest = rest.trim_end();
+        let (rest, fc) = match rest.rfind('[') {
+            Some(idx) => {
+                let fc = FunctionalConstraint::from_str(&rest[idx + 1..rest.len() - 1]);
+                (&rest[..idx], fc)
+            }
+            None => (rest, None),
+        };
+
+        let steps = parse_model_path(rest);
+        let ln_name = match steps.first()? {
+            PathStep::Component(name) => name,
+            PathStep::Index(_) => return None,
+        };
+        let ln = self.find_logical_node(ld_inst, ln_name)?;
+
+        // LN-level reference with optional FC group: read the matching FC group.
+        if steps.len() == 1 {
+            return fc.and_then(|fc: FunctionalConstraint| self.read_ln_fc_group(ln, fc));
+        }
+
+        let do_name = match steps.get(1)? {
+            PathStep::Component(name) => name,
+            PathStep::Index(_) => return None,
+        };
+        let current_do = ln.find_data_object(do_name)?;
+
+        self.read_data_object_steps(current_do, &steps[2..])
+    }
+
+    /// Reads all data objects under an LN that belong to the given functional
+    /// constraint as a single structure. Each matching data object becomes a
+    /// named component whose value is a structure of its leaf children.
+    fn read_ln_fc_group(
+        &self,
+        ln: &LogicalNodeNode,
+        fc: FunctionalConstraint,
+    ) -> Option<DataValue> {
+        let values: Vec<DataValue> = ln
+            .data_objects
+            .iter()
+            .filter(|do_| fc_for_data_object(do_).map_or(false, |do_fc| do_fc == fc))
+            .map(|do_| do_.read_values(&self.value_store))
+            .collect::<Option<Vec<_>>>()?;
+        Some(DataValue::Struct(Arc::new(values)))
+    }
+
+    fn read_data_object_steps(
+        &self,
+        do_node: &DataObjectNode,
+        steps: &[PathStep],
+    ) -> Option<DataValue> {
+        if steps.is_empty() {
+            return do_node.read_values(&self.value_store);
+        }
+
+        let name = match steps.first()? {
+            PathStep::Component(name) => name,
+            PathStep::Index(_) => return None,
+        };
+
+        match do_node.find_child(name)? {
+            DataObjectChild::Attribute(da) => self.read_attribute_with_steps(da, &steps[1..]),
+            DataObjectChild::SubObject(sdo) => self.read_data_object_steps(sdo, &steps[1..]),
+            DataObjectChild::AttributeArray { elements, .. } => match steps.get(1) {
+                None => {
+                    let values: Vec<DataValue> = elements
+                        .iter()
+                        .map(|elem| elem.read_values(&self.value_store))
+                        .collect::<Option<Vec<_>>>()?;
+                    Some(DataValue::Array(Arc::new(values)))
+                }
+                Some(PathStep::Index(idx)) => {
+                    let elem = elements.get(*idx as usize)?;
+                    self.read_attribute_with_steps(elem, &steps[2..])
+                }
+                Some(PathStep::Component(_)) => None,
+            },
+            DataObjectChild::SubObjectArray { elements, .. } => match steps.get(1) {
+                None => {
+                    let values: Vec<DataValue> = elements
+                        .iter()
+                        .map(|elem| elem.read_values(&self.value_store))
+                        .collect::<Option<Vec<_>>>()?;
+                    Some(DataValue::Array(Arc::new(values)))
+                }
+                Some(PathStep::Index(idx)) => {
+                    let elem = elements.get(*idx as usize)?;
+                    self.read_data_object_steps(elem, &steps[2..])
+                }
+                Some(PathStep::Component(_)) => None,
+            },
+        }
+    }
+
+    fn read_attribute_with_steps(
+        &self,
+        da: &DataAttributeNode,
+        steps: &[PathStep],
+    ) -> Option<DataValue> {
+        match steps.first() {
+            None => da.read_values(&self.value_store),
+            Some(PathStep::Component(name)) => match da {
+                DataAttributeNode::Struct { children, .. } => {
+                    let child = children.iter().find(|c| c.name() == name)?;
+                    self.read_attribute_with_steps(child, &steps[1..])
+                }
+                _ => None,
+            },
+            Some(PathStep::Index(idx)) => match da {
+                DataAttributeNode::Leaf { reference, .. } => {
+                    let value = self.value_store.read(reference).ok()?;
+                    apply_index_to_value(&value, *idx, &steps[1..])
+                }
+                DataAttributeNode::Array { elements, .. } => {
+                    let elem = elements.get(*idx as usize)?;
+                    self.read_attribute_with_steps(elem, &steps[1..])
+                }
+                _ => None,
+            },
+        }
+    }
+
+    /// Resolves the data definition at a model path.
+    ///
+    /// The path uses the same internal model notation as [`Self::read_by_path`]:
+    /// `{ied_name}{ld_inst}/{ln_name}.{do_name}[.{child_name}]*`
+    ///
+    /// An optional trailing `[FC]` is ignored. Array indices may be embedded
+    /// using parentheses. The method returns the type definition of the node
+    /// referenced by the path, which may be a leaf, a structure, or an array.
+    ///
+    /// Per IEC 61850-7-2, a reference that stops at the Logical Node level
+    /// (`{ied_name}{ld_inst}/{ln_name}`) is also valid. The response describes
+    /// the LN as a structure whose first-level components are the functional
+    /// constraints, each containing the DOs/DAs that share that FC.
+    pub fn get_data_definition_by_path(&self, path: &str) -> Option<DataDefinition> {
+        let (domain, rest) = path.split_once('/')?;
+        let ld_inst = domain.strip_prefix(&self.ied_name).unwrap_or(domain);
+
+        let rest = rest.trim_end();
+        let rest = match rest.rfind('[') {
+            Some(idx) => &rest[..idx],
+            None => rest,
+        };
+
+        let steps = parse_model_path(rest);
+        let ln_name = match steps.first()? {
+            PathStep::Component(name) => name,
+            PathStep::Index(_) => return None,
+        };
+        let ln = self.find_logical_node(ld_inst, ln_name)?;
+
+        match steps.get(1) {
+            None => Some(self.get_logical_node_definition(ln)),
+            Some(PathStep::Component(do_name)) => {
+                let current_do = ln.find_data_object(do_name)?;
+                self.get_data_object_definition(current_do, &steps[2..])
+            }
+            Some(PathStep::Index(_)) => None,
+        }
+    }
+
+    /// Builds the data definition for a whole Logical Node.
+    ///
+    /// All data objects of the LN are grouped by their functional constraint.
+    /// The returned structure has one component per distinct FC, in first-seen
+    /// order, and each FC component is itself a structure containing the
+    /// matching data objects. A data object that contains children with
+    /// different functional constraints may appear under multiple FC groups,
+    /// once for each FC, containing only the children that share that FC.
+    fn get_logical_node_definition(&self, ln: &LogicalNodeNode) -> DataDefinition {
+        let mut fc_groups: Vec<(FunctionalConstraint, Vec<DataDefinition>)> = Vec::new();
+
+        for do_node in &ln.data_objects {
+            let do_fcs = fc_set_for_data_object(do_node);
+            for fc in do_fcs {
+                let filtered = filter_children_by_fc(&do_node.children, fc);
+                if filtered.is_empty() {
+                    continue;
+                }
+                let children = self.data_object_children_to_data_type(&filtered);
+                push_to_fc_group(
+                    &mut fc_groups,
+                    fc,
+                    DataDefinition {
+                        name: do_node.name.clone(),
+                        data_type: children,
+                    },
+                );
+            }
+        }
+
+        let fc_components = fc_groups
+            .into_iter()
+            .map(|(fc, children)| DataDefinition {
+                name: fc.as_str().to_string(),
+                data_type: DataType::Structure(children),
+            })
+            .collect();
+
+        DataDefinition {
+            name: format!("{}{}{}", ln.ln_prefix, ln.ln_class, ln.inst),
+            data_type: DataType::Structure(fc_components),
+        }
+    }
+
+    fn get_data_object_definition(
+        &self,
+        do_node: &DataObjectNode,
+        steps: &[PathStep],
+    ) -> Option<DataDefinition> {
+        if steps.is_empty() {
+            return Some(DataDefinition {
+                name: do_node.name.clone(),
+                data_type: self.data_object_children_to_data_type(&do_node.children),
+            });
+        }
+
+        match steps.first()? {
+            PathStep::Component(name) => match do_node.find_child(name)? {
+                DataObjectChild::Attribute(da) => {
+                    self.get_data_attribute_definition(da, &steps[1..])
+                }
+                DataObjectChild::SubObject(sdo) => {
+                    self.get_data_object_definition(sdo, &steps[1..])
+                }
+                DataObjectChild::AttributeArray {
+                    name: array_name,
+                    count,
+                    elements,
+                    ..
+                } => match steps.get(1) {
+                    None => Some(DataDefinition {
+                        name: array_name.clone(),
+                        data_type: DataType::Array {
+                            count: *count,
+                            element_type: Box::new(
+                                self.get_data_attribute_definition(&elements[0], &[])?
+                                    .data_type,
+                            ),
+                        },
+                    }),
+                    Some(PathStep::Index(idx)) => self
+                        .get_data_attribute_definition(elements.get(*idx as usize)?, &steps[2..]),
+                    Some(PathStep::Component(_)) => None,
+                },
+                DataObjectChild::SubObjectArray {
+                    name: array_name,
+                    count,
+                    elements,
+                    ..
+                } => match steps.get(1) {
+                    None => Some(DataDefinition {
+                        name: array_name.clone(),
+                        data_type: DataType::Array {
+                            count: *count,
+                            element_type: Box::new(
+                                self.get_data_object_definition(&elements[0], &[])?
+                                    .data_type,
+                            ),
+                        },
+                    }),
+                    Some(PathStep::Index(idx)) => {
+                        self.get_data_object_definition(elements.get(*idx as usize)?, &steps[2..])
+                    }
+                    Some(PathStep::Component(_)) => None,
+                },
+            },
+            PathStep::Index(_) => None,
+        }
+    }
+
+    fn get_data_attribute_definition(
+        &self,
+        da: &DataAttributeNode,
+        steps: &[PathStep],
+    ) -> Option<DataDefinition> {
+        match steps.first() {
+            None => Some(DataDefinition {
+                name: da.name().to_string(),
+                data_type: self.data_attribute_node_to_data_type(da),
+            }),
+            Some(PathStep::Component(name)) => match da {
+                DataAttributeNode::Struct { children, .. } => {
+                    let child = children.iter().find(|c| c.name() == name)?;
+                    self.get_data_attribute_definition(child, &steps[1..])
+                }
+                _ => None,
+            },
+            Some(PathStep::Index(idx)) => match da {
+                DataAttributeNode::Array { elements, .. } => {
+                    let elem = elements.get(*idx as usize)?;
+                    self.get_data_attribute_definition(elem, &steps[1..])
+                }
+                _ => None,
+            },
+        }
+    }
+
+    fn data_attribute_node_to_data_type(&self, da: &DataAttributeNode) -> DataType {
+        match da {
+            DataAttributeNode::Leaf { attribute_type, .. } => {
+                attribute_type_to_data_type(*attribute_type)
+            }
+            DataAttributeNode::Struct { children, .. } => DataType::Structure(
+                children
+                    .iter()
+                    .map(|child| {
+                        self.get_data_attribute_definition(child, &[])
+                            .expect("child resolves")
+                    })
+                    .collect(),
+            ),
+            DataAttributeNode::Array {
+                count, elements, ..
+            } => DataType::Array {
+                count: *count,
+                element_type: Box::new(
+                    self.get_data_attribute_definition(&elements[0], &[])
+                        .expect("array has element")
+                        .data_type,
+                ),
+            },
+        }
+    }
+
+    fn data_object_children_to_data_type(&self, children: &[DataObjectChild]) -> DataType {
+        DataType::Structure(
+            children
+                .iter()
+                .map(|child| match child {
+                    DataObjectChild::Attribute(da) => self
+                        .get_data_attribute_definition(da, &[])
+                        .expect("child resolves"),
+                    DataObjectChild::SubObject(sdo) => self
+                        .get_data_object_definition(sdo, &[])
+                        .expect("child resolves"),
+                    DataObjectChild::AttributeArray {
+                        name,
+                        count,
+                        elements,
+                        ..
+                    } => DataDefinition {
+                        name: name.clone(),
+                        data_type: DataType::Array {
+                            count: *count,
+                            element_type: Box::new(
+                                self.get_data_attribute_definition(&elements[0], &[])
+                                    .expect("array has element")
+                                    .data_type,
+                            ),
+                        },
+                    },
+                    DataObjectChild::SubObjectArray {
+                        name,
+                        count,
+                        elements,
+                        ..
+                    } => DataDefinition {
+                        name: name.clone(),
+                        data_type: DataType::Array {
+                            count: *count,
+                            element_type: Box::new(
+                                self.get_data_object_definition(&elements[0], &[])
+                                    .expect("array has element")
+                                    .data_type,
+                            ),
+                        },
+                    },
+                })
+                .collect(),
+        )
+    }
+
     /// Loads a `ServerModel` from a JSON string.
     pub fn from_json(json: &str) -> Result<Self, ModelLoadError> {
         let model: CompiledModel = serde_json::from_str(json)?;
-        let logical_devices = model.logical_devices.into_iter().map(build_ld).collect();
+        let ied_name = model.ied_name.clone();
+
+        let mut builder = ModelBuilder::new(ied_name.clone());
+
+        let logical_devices: Result<Vec<_>, _> = model
+            .logical_devices
+            .into_iter()
+            .map(|ld| builder.build_logical_device(ld))
+            .collect();
+
         Ok(Self {
-            ied_name: model.ied_name,
+            ied_name,
             config: IedConfig {
                 max_associations: model.config.max_associations,
             },
-            logical_devices,
+            logical_devices: logical_devices?,
+            value_store: builder.value_store,
+            reference_to_path: builder.reference_to_path,
         })
     }
 
@@ -205,42 +894,954 @@ impl ServerModel {
     }
 }
 
-// ─── Builders ────────────────────────────────────────────────────────────────
+/// Collects all leaf/structural definitions under a set of DO children into
+/// FC-ordered groups. The `parent_name` is prepended to sub-object names so
+/// that `A.phsA.cVal.mag.f` stays distinguishable from `A.phsA.cVal.ang.f`.
+/// Determines the functional constraint of a DataObject from its children.
+fn fc_for_data_object(do_node: &DataObjectNode) -> Option<FunctionalConstraint> {
+    do_node.children.iter().find_map(|child| match child {
+        DataObjectChild::Attribute(da) => Some(da.fc()),
+        DataObjectChild::AttributeArray { fc, .. } => Some(*fc),
+        DataObjectChild::SubObject(sdo) => fc_for_data_object(sdo),
+        DataObjectChild::SubObjectArray { elements, .. } => {
+            elements.first().and_then(fc_for_data_object)
+        }
+    })
+}
 
-fn build_ld(ld: CompiledLogicalDevice) -> LogicalDeviceNode {
-    LogicalDeviceNode {
-        inst: ld.inst,
-        logical_nodes: ld.logical_nodes.into_iter().map(build_ln).collect(),
+/// Returns every distinct functional constraint used by any child of the
+/// data object, preserving first-seen order.
+fn fc_set_for_data_object(do_node: &DataObjectNode) -> Vec<FunctionalConstraint> {
+    let mut fcs = Vec::new();
+    for child in &do_node.children {
+        let child_fcs: Vec<FunctionalConstraint> = match child {
+            DataObjectChild::Attribute(da) => vec![da.fc()],
+            DataObjectChild::AttributeArray { fc, .. } => vec![*fc],
+            DataObjectChild::SubObject(sdo) => fc_set_for_data_object(sdo),
+            DataObjectChild::SubObjectArray { elements, .. } => elements
+                .first()
+                .map(|e| fc_set_for_data_object(e))
+                .unwrap_or_default(),
+        };
+        for fc in child_fcs {
+            if !fcs.contains(&fc) {
+                fcs.push(fc);
+            }
+        }
+    }
+    fcs
+}
+
+/// Filters the children of a data object, keeping only the children (and their
+/// nested descendants) whose functional constraint matches `fc`.
+fn filter_children_by_fc(
+    children: &[DataObjectChild],
+    fc: FunctionalConstraint,
+) -> Vec<DataObjectChild> {
+    children
+        .iter()
+        .filter_map(|child| match child {
+            DataObjectChild::Attribute(da) if da.fc() == fc => {
+                Some(DataObjectChild::Attribute(da.clone()))
+            }
+            DataObjectChild::AttributeArray {
+                name,
+                fc: array_fc,
+                count,
+                elements,
+            } if *array_fc == fc => Some(DataObjectChild::AttributeArray {
+                name: name.clone(),
+                fc: *array_fc,
+                count: *count,
+                elements: elements.clone(),
+            }),
+            DataObjectChild::SubObject(sdo) => {
+                let filtered = filter_children_by_fc(&sdo.children, fc);
+                if filtered.is_empty() {
+                    None
+                } else {
+                    Some(DataObjectChild::SubObject(DataObjectNode {
+                        name: sdo.name.clone(),
+                        children: filtered,
+                    }))
+                }
+            }
+            DataObjectChild::SubObjectArray {
+                name,
+                count,
+                elements,
+            } => {
+                let filtered_elements: Vec<_> = elements
+                    .iter()
+                    .map(|e| {
+                        let filtered = filter_children_by_fc(&e.children, fc);
+                        DataObjectNode {
+                            name: e.name.clone(),
+                            children: filtered,
+                        }
+                    })
+                    .filter(|e| !e.children.is_empty())
+                    .collect();
+                if filtered_elements.is_empty() {
+                    None
+                } else {
+                    Some(DataObjectChild::SubObjectArray {
+                        name: name.clone(),
+                        count: *count,
+                        elements: filtered_elements,
+                    })
+                }
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn push_to_fc_group(
+    fc_groups: &mut Vec<(FunctionalConstraint, Vec<DataDefinition>)>,
+    fc: FunctionalConstraint,
+    def: DataDefinition,
+) {
+    match fc_groups
+        .iter_mut()
+        .find(|(existing_fc, _)| *existing_fc == fc)
+    {
+        Some((_, group)) => group.push(def),
+        None => fc_groups.push((fc, vec![def])),
     }
 }
 
-fn build_ln(ln: CompiledLogicalNode) -> LogicalNodeNode {
-    LogicalNodeNode {
-        ln_class: ln.ln_class,
-        inst: ln.inst,
-        prefix: ln.prefix,
-        data_objects: ln.data_objects.into_iter().map(build_do).collect(),
+/// Builder that constructs the runtime [`ServerModel`] from a compiled model.
+///
+/// While walking the structural tree, the builder registers every leaf
+/// DataAttribute in the [`LeafDataStore`] and records the mapping from
+/// [`DataRef`] back to the original IEC 61850 path.
+struct ModelBuilder {
+    ied_name: String,
+    value_store: LeafDataStore,
+    reference_to_path: HashMap<DataRef, String>,
+}
+
+impl ModelBuilder {
+    fn new(ied_name: String) -> Self {
+        Self {
+            ied_name,
+            value_store: LeafDataStore::new(),
+            reference_to_path: HashMap::new(),
+        }
+    }
+
+    fn build_logical_device(
+        &mut self,
+        ld: CompiledLogicalDevice,
+    ) -> Result<LogicalDeviceNode, ModelLoadError> {
+        let inst = ld.inst.clone();
+        let mut logical_nodes = Vec::with_capacity(ld.logical_nodes.len());
+        for ln in ld.logical_nodes {
+            logical_nodes.push(self.build_logical_node(&inst, ln)?);
+        }
+        Ok(LogicalDeviceNode {
+            inst,
+            logical_nodes,
+        })
+    }
+
+    fn build_logical_node(
+        &mut self,
+        ld_inst: &str,
+        ln: CompiledLogicalNode,
+    ) -> Result<LogicalNodeNode, ModelLoadError> {
+        let ln_prefix = ln.prefix.clone();
+        let ln_class = ln.ln_class.clone();
+        let inst = ln.inst.clone();
+
+        let ln_path = format!(
+            "{}{}/{}{}{}",
+            self.ied_name.clone(),
+            ld_inst,
+            ln_prefix,
+            ln_class,
+            inst
+        );
+
+        let mut data_objects = Vec::with_capacity(ln.data_objects.len());
+        for do_ in ln.data_objects {
+            data_objects.push(self.build_data_object(&ln_path, do_)?);
+        }
+
+        Ok(LogicalNodeNode {
+            ln_class,
+            inst,
+            ln_prefix,
+            data_objects,
+        })
+    }
+
+    fn build_data_object(
+        &mut self,
+        parent_path: &str,
+        do_: CompiledDataObject,
+    ) -> Result<DataObjectNode, ModelLoadError> {
+        self.build_data_object_with_index(parent_path, do_, None)
+    }
+
+    fn build_data_object_with_index(
+        &mut self,
+        parent_path: &str,
+        do_: CompiledDataObject,
+        index: Option<u32>,
+    ) -> Result<DataObjectNode, ModelLoadError> {
+        let path = match index {
+            Some(i) => format!("{parent_path}.{}({i})", do_.name),
+            None => format!("{parent_path}.{}", do_.name),
+        };
+        Ok(DataObjectNode {
+            name: do_.name.clone(),
+            children: do_
+                .children
+                .into_iter()
+                .map(|child| self.build_data_object_child(&path, child))
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+
+    fn build_data_object_child(
+        &mut self,
+        parent_path: &str,
+        child: CompiledDataObjectChild,
+    ) -> Result<DataObjectChild, ModelLoadError> {
+        match child {
+            CompiledDataObjectChild::Attribute(da) => {
+                let count = if da.count == 0 { 1 } else { da.count };
+                if count > 1 {
+                    let name = da.name.clone();
+                    let fc = da.fc;
+                    let elements: Result<Vec<_>, _> = (0..count)
+                        .map(|i| {
+                            self.build_data_attribute_with_index(parent_path, da.clone(), Some(i))
+                        })
+                        .collect();
+                    Ok(DataObjectChild::AttributeArray {
+                        name,
+                        fc,
+                        count,
+                        elements: elements?,
+                    })
+                } else {
+                    Ok(DataObjectChild::Attribute(
+                        self.build_data_attribute(parent_path, da)?,
+                    ))
+                }
+            }
+            CompiledDataObjectChild::SubObject(sdo) => {
+                let count = if sdo.count == 0 { 1 } else { sdo.count };
+                if count > 1 {
+                    let name = sdo.name.clone();
+                    let elements: Result<Vec<_>, _> = (0..count)
+                        .map(|i| {
+                            self.build_data_object_with_index(parent_path, sdo.clone(), Some(i))
+                        })
+                        .collect();
+                    Ok(DataObjectChild::SubObjectArray {
+                        name,
+                        count,
+                        elements: elements?,
+                    })
+                } else {
+                    Ok(DataObjectChild::SubObject(
+                        self.build_data_object(parent_path, sdo)?,
+                    ))
+                }
+            }
+        }
+    }
+
+    fn build_data_attribute(
+        &mut self,
+        parent_path: &str,
+        da: CompiledDataAttribute,
+    ) -> Result<DataAttributeNode, ModelLoadError> {
+        self.build_data_attribute_with_index(parent_path, da, None)
+    }
+
+    fn build_data_attribute_with_index(
+        &mut self,
+        parent_path: &str,
+        da: CompiledDataAttribute,
+        index: Option<u32>,
+    ) -> Result<DataAttributeNode, ModelLoadError> {
+        // Clone the name up-front so the descriptor can be reused when
+        // expanding an array into multiple elements.
+        let name = da.name.clone();
+        let fc = da.fc;
+        let count = if da.count == 0 { 1 } else { da.count };
+
+        if count > 1 && index.is_none() {
+            let elements: Result<Vec<_>, _> = (0..count)
+                .map(|i| self.build_data_attribute_with_index(parent_path, da.clone(), Some(i)))
+                .collect();
+            return Ok(DataAttributeNode::Array {
+                name,
+                fc,
+                count,
+                elements: elements?,
+            });
+        }
+
+        let path = match index {
+            Some(i) => format!("{parent_path}.{}({i})", name),
+            None => format!("{parent_path}.{name}"),
+        };
+
+        if da.children.is_empty() {
+            let attribute_type = match da.attribute_type {
+                Some(t) => Some(t),
+                None => {
+                    return Err(ModelLoadError::MissingAttributeType { path });
+                }
+            };
+            let reference = DataRef::new(&path);
+            let initial = default_value_for_type(attribute_type);
+
+            self.value_store.register(reference.clone(), initial);
+            self.reference_to_path
+                .insert(reference.clone(), path.clone());
+
+            Ok(DataAttributeNode::Leaf {
+                name,
+                fc,
+                reference,
+                attribute_type,
+            })
+        } else {
+            let children: Result<Vec<_>, _> = da
+                .children
+                .into_iter()
+                .map(|child| self.build_data_attribute(&path, child))
+                .collect();
+            Ok(DataAttributeNode::Struct {
+                name,
+                fc,
+                children: children?,
+            })
+        }
     }
 }
 
-fn build_do(do_: CompiledDataObject) -> DataObjectNode {
-    DataObjectNode {
-        name: do_.name,
-        children: do_.children.into_iter().map(build_do_child).collect(),
+/// Returns a sensible default value for a leaf based on its declared type.
+/// When no type is given, the generic boolean placeholder is used.
+fn default_value_for_type(attribute_type: Option<AttributeType>) -> DataValue {
+    match attribute_type {
+        Some(AttributeType::Bool) => DataValue::Bool(false),
+        Some(AttributeType::Int32) => DataValue::Int32(0),
+        Some(AttributeType::Float32) => DataValue::Float32(0.0),
+        Some(AttributeType::Quality) => DataValue::Quality(Quality::default()),
+        Some(AttributeType::Timestamp) => {
+            DataValue::Timestamp(Timestamp::from_unix_timestamp(0.0, TimeQuality::default()))
+        }
+        Some(AttributeType::VisibleString) => DataValue::VisibleString(String::new()),
+        None => DataValue::default_placeholder(),
     }
 }
 
-fn build_do_child(child: CompiledDataObjectChild) -> DataObjectChild {
-    match child {
-        CompiledDataObjectChild::Attribute(da) => DataObjectChild::Attribute(build_da(da)),
-        CompiledDataObjectChild::SubObject(sdo) => DataObjectChild::SubObject(build_do(sdo)),
+/// Maps a compiled leaf attribute type to its public [`DataType`] representation.
+///
+/// `None` falls back to [`DataType::VisibleString`] so that untyped leaves can
+/// still be described without failing the service.
+fn attribute_type_to_data_type(attribute_type: Option<AttributeType>) -> DataType {
+    match attribute_type {
+        Some(AttributeType::Bool) => DataType::Boolean,
+        Some(AttributeType::Int32) => DataType::Int,
+        Some(AttributeType::Float32) => DataType::Float,
+        Some(AttributeType::Quality) => DataType::BitString,
+        Some(AttributeType::Timestamp) => DataType::Timestamp,
+        Some(AttributeType::VisibleString) => DataType::VisibleString,
+        None => DataType::VisibleString,
     }
 }
 
-fn build_da(da: CompiledDataAttribute) -> DataAttributeNode {
-    DataAttributeNode {
-        name: da.name,
-        fc: da.fc,
-        children: da.children.into_iter().map(build_da).collect(),
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_MODEL: &str = r#"{
+        "ied_name": "TEMPLATE",
+        "config": { "max_associations": 5 },
+        "logical_devices": [
+            {
+                "inst": "LD0",
+                "logical_nodes": [
+                    {
+                        "ln_class": "LLN0",
+                        "inst": "0",
+                        "data_objects": [
+                            {
+                                "name": "NamPlt",
+                                "children": [
+                                    { "type": "Attribute", "name": "vendor", "fc": "DC", "da_type": "visible_string" }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    #[test]
+    fn model_loads_and_registers_leaf_reference() {
+        let model = ServerModel::from_json(TEST_MODEL).expect("valid model");
+        let reference = DataRef::new("TEMPLATELD0/LLN00.NamPlt.vendor");
+
+        assert_eq!(model.ied_name, "TEMPLATE");
+        assert!(model.value_store.read(&reference).is_ok());
+    }
+
+    #[test]
+    fn model_builds_nested_sdo_and_da_paths() {
+        let json = r#"{
+            "ied_name": "IED",
+            "config": { "max_associations": 5 },
+            "logical_devices": [
+                {
+                    "inst": "LD0",
+                    "logical_nodes": [
+                        {
+                            "ln_class": "MMXU",
+                            "inst": "1",
+                            "prefix": "Pref",
+                            "data_objects": [
+                                {
+                                    "name": "A",
+                                    "children": [
+                                        {
+                                            "type": "SubObject",
+                                            "name": "phsA",
+                                            "children": [
+                                                {
+                                                    "type": "Attribute",
+                                                    "name": "cVal",
+                                                    "fc": "MX",
+                                                    "children": [
+                                                        {
+                                                            "name": "mag",
+                                                            "fc": "MX",
+                                                            "children": [
+                                                                { "name": "f", "fc": "MX", "da_type": "float32" }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let model = ServerModel::from_json(json).expect("valid model");
+        let reference = DataRef::new("IEDLD0/PrefMMXU1.A.phsA.cVal.mag.f");
+
+        assert!(model.value_store.read(&reference).is_ok());
+        assert_eq!(
+            model.reference_to_path.get(&reference),
+            Some(&"IEDLD0/PrefMMXU1.A.phsA.cVal.mag.f".to_string())
+        );
+    }
+
+    #[test]
+    fn model_builds_array_of_leaf_attributes() {
+        let json = r#"{
+            "ied_name": "ARRAY",
+            "config": { "max_associations": 5 },
+            "logical_devices": [
+                {
+                    "inst": "LD0",
+                    "logical_nodes": [
+                        {
+                            "ln_class": "LLN0",
+                            "inst": "0",
+                            "data_objects": [
+                                {
+                                    "name": "Hrs",
+                                    "children": [
+                                        {
+                                            "type": "Attribute",
+                                            "name": "hr",
+                                            "fc": "ST",
+                                            "count": 3,
+                                            "da_type": "int32"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let model = ServerModel::from_json(json).expect("valid model");
+
+        for i in 0..3 {
+            let reference = DataRef::new(format!("ARRAYLD0/LLN00.Hrs.hr({i})"));
+            assert!(model.value_store.read(&reference).is_ok());
+        }
+
+        assert_eq!(
+            model.read_by_path("ARRAYLD0/LLN00.Hrs.hr(1)"),
+            Some(DataValue::Int32(0))
+        );
+
+        assert_eq!(
+            model.read_by_path("ARRAYLD0/LLN00.Hrs.hr[ST]"),
+            Some(DataValue::Array(Arc::new(vec![
+                DataValue::Int32(0),
+                DataValue::Int32(0),
+                DataValue::Int32(0),
+            ])))
+        );
+    }
+
+    #[test]
+    fn model_builds_array_of_sub_objects() {
+        let json = r#"{
+            "ied_name": "FCSD",
+            "config": { "max_associations": 5 },
+            "logical_devices": [
+                {
+                    "inst": "LD0",
+                    "logical_nodes": [
+                        {
+                            "ln_class": "FCSD",
+                            "inst": "1",
+                            "data_objects": [
+                                {
+                                    "name": "Crv",
+                                    "children": [
+                                        {
+                                            "type": "SubObject",
+                                            "name": "crvPts",
+                                            "count": 2,
+                                            "children": [
+                                                {
+                                                    "type": "Attribute",
+                                                    "name": "x",
+                                                    "fc": "CF",
+                                                    "da_type": "int32"
+                                                },
+                                                {
+                                                    "type": "Attribute",
+                                                    "name": "y",
+                                                    "fc": "CF",
+                                                    "da_type": "int32"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let model = ServerModel::from_json(json).expect("valid model");
+
+        for i in 0..2 {
+            let x_ref = DataRef::new(format!("FCSDLD0/FCSD1.Crv.crvPts({i}).x"));
+            let y_ref = DataRef::new(format!("FCSDLD0/FCSD1.Crv.crvPts({i}).y"));
+            assert!(model.value_store.read(&x_ref).is_ok());
+            assert!(model.value_store.read(&y_ref).is_ok());
+        }
+
+        assert_eq!(
+            model.read_by_path("FCSDLD0/FCSD1.Crv.crvPts(1).x[CF]"),
+            Some(DataValue::Int32(0))
+        );
+
+        let element = DataValue::Struct(Arc::new(vec![DataValue::Int32(0), DataValue::Int32(0)]));
+        assert_eq!(
+            model.read_by_path("FCSDLD0/FCSD1.Crv.crvPts"),
+            Some(DataValue::Array(Arc::new(vec![element.clone(), element])))
+        );
+    }
+
+    #[test]
+    fn model_returns_data_definition_for_leaf() {
+        let json = r#"{
+            "ied_name": "IED",
+            "config": { "max_associations": 5 },
+            "logical_devices": [
+                {
+                    "inst": "LD0",
+                    "logical_nodes": [
+                        {
+                            "ln_class": "MMXU",
+                            "inst": "1",
+                            "data_objects": [
+                                {
+                                    "name": "A",
+                                    "children": [
+                                        {
+                                            "type": "Attribute",
+                                            "name": "phsA",
+                                            "fc": "MX",
+                                            "children": [
+                                                {
+                                                    "name": "cVal",
+                                                    "fc": "MX",
+                                                    "children": [
+                                                        {
+                                                            "name": "mag",
+                                                            "fc": "MX",
+                                                            "children": [
+                                                                { "name": "f", "fc": "MX", "da_type": "float32" }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let model = ServerModel::from_json(json).expect("valid model");
+        let def = model
+            .get_data_definition_by_path("IEDLD0/MMXU1.A.phsA.cVal.mag.f[MX]")
+            .expect("definition exists");
+
+        assert_eq!(def.name, "f");
+        assert_eq!(def.data_type, DataType::Float);
+    }
+
+    #[test]
+    fn model_returns_data_definition_for_structure() {
+        let json = r#"{
+            "ied_name": "IED",
+            "config": { "max_associations": 5 },
+            "logical_devices": [
+                {
+                    "inst": "LD0",
+                    "logical_nodes": [
+                        {
+                            "ln_class": "MMXU",
+                            "inst": "1",
+                            "data_objects": [
+                                {
+                                    "name": "A",
+                                    "children": [
+                                        {
+                                            "type": "Attribute",
+                                            "name": "phsA",
+                                            "fc": "MX",
+                                            "children": [
+                                                {
+                                                    "name": "cVal",
+                                                    "fc": "MX",
+                                                    "children": [
+                                                        {
+                                                            "name": "mag",
+                                                            "fc": "MX",
+                                                            "children": [
+                                                                { "name": "f", "fc": "MX", "da_type": "float32" }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let model = ServerModel::from_json(json).expect("valid model");
+        let def = model
+            .get_data_definition_by_path("IEDLD0/MMXU1.A.phsA.cVal[MX]")
+            .expect("definition exists");
+
+        assert_eq!(def.name, "cVal");
+        assert!(
+            matches!(def.data_type, DataType::Structure(ref children) if children.len() == 1 && children[0].name == "mag")
+        );
+    }
+
+    #[test]
+    fn model_returns_data_definition_for_array() {
+        let json = r#"{
+            "ied_name": "ARRAY",
+            "config": { "max_associations": 5 },
+            "logical_devices": [
+                {
+                    "inst": "LD0",
+                    "logical_nodes": [
+                        {
+                            "ln_class": "LLN0",
+                            "inst": "0",
+                            "data_objects": [
+                                {
+                                    "name": "Hrs",
+                                    "children": [
+                                        {
+                                            "type": "Attribute",
+                                            "name": "hr",
+                                            "fc": "ST",
+                                            "count": 3,
+                                            "da_type": "int32"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let model = ServerModel::from_json(json).expect("valid model");
+
+        let array_def = model
+            .get_data_definition_by_path("ARRAYLD0/LLN00.Hrs.hr[ST]")
+            .expect("array definition exists");
+        assert_eq!(array_def.name, "hr");
+        assert!(
+            matches!(array_def.data_type, DataType::Array { count: 3, ref element_type } if *element_type.as_ref() == DataType::Int)
+        );
+
+        let element_def = model
+            .get_data_definition_by_path("ARRAYLD0/LLN00.Hrs.hr(1)[ST]")
+            .expect("element definition exists");
+        assert_eq!(element_def.name, "hr");
+        assert_eq!(element_def.data_type, DataType::Int);
+    }
+
+    #[test]
+    fn model_returns_data_definition_for_logical_node() {
+        let json = r#"{
+            "ied_name": "IED",
+            "config": { "max_associations": 5 },
+            "logical_devices": [
+                {
+                    "inst": "LD0",
+                    "logical_nodes": [
+                        {
+                            "ln_class": "LLN0",
+                            "inst": "",
+                            "data_objects": [
+                                {
+                                    "name": "Mod",
+                                    "children": [
+                                        { "type": "Attribute", "name": "stVal", "fc": "ST", "da_type": "bool" }
+                                    ]
+                                },
+                                {
+                                    "name": "NamPlt",
+                                    "children": [
+                                        { "type": "Attribute", "name": "vendor", "fc": "DC", "da_type": "visible_string" }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let model = ServerModel::from_json(json).expect("valid model");
+        let def = model
+            .get_data_definition_by_path("IEDLD0/LLN0")
+            .expect("definition exists");
+
+        assert_eq!(def.name, "LLN0");
+        match def.data_type {
+            DataType::Structure(fc_groups) => {
+                assert_eq!(fc_groups.len(), 2);
+                assert_eq!(fc_groups[0].name, "ST");
+                assert_eq!(fc_groups[1].name, "DC");
+
+                // ST group contains one DO: Mod
+                match &fc_groups[0].data_type {
+                    DataType::Structure(dos) => {
+                        assert_eq!(dos.len(), 1);
+                        assert_eq!(dos[0].name, "Mod");
+                    }
+                    other => panic!("expected ST to be structure of DOs, got {:?}", other),
+                }
+
+                // DC group contains one DO: NamPlt
+                match &fc_groups[1].data_type {
+                    DataType::Structure(dos) => {
+                        assert_eq!(dos.len(), 1);
+                        assert_eq!(dos[0].name, "NamPlt");
+                    }
+                    other => panic!("expected DC to be structure of DOs, got {:?}", other),
+                }
+            }
+            other => panic!("expected structure, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn model_groups_data_object_children_by_fc_in_logical_node_definition() {
+        let json = r#"{
+            "ied_name": "IED",
+            "config": { "max_associations": 5 },
+            "logical_devices": [
+                {
+                    "inst": "LD0",
+                    "logical_nodes": [
+                        {
+                            "ln_class": "MHAI",
+                            "inst": "1",
+                            "data_objects": [
+                                {
+                                    "name": "HA",
+                                    "children": [
+                                        {
+                                            "type": "SubObject",
+                                            "name": "phsAHar",
+                                            "count": 16,
+                                            "children": [
+                                                {
+                                                    "type": "Attribute",
+                                                    "name": "cVal",
+                                                    "fc": "MX",
+                                                    "children": [
+                                                        {
+                                                            "name": "mag",
+                                                            "fc": "MX",
+                                                            "children": [
+                                                                { "name": "f", "fc": "MX", "da_type": "float32" }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "Attribute",
+                                                    "name": "q",
+                                                    "fc": "MX",
+                                                    "da_type": "quality"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "Attribute",
+                                            "name": "numHar",
+                                            "fc": "CF",
+                                            "da_type": "int32"
+                                        },
+                                        {
+                                            "type": "Attribute",
+                                            "name": "numCyc",
+                                            "fc": "CF",
+                                            "da_type": "int32"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let model = ServerModel::from_json(json).expect("valid model");
+        let def = model
+            .get_data_definition_by_path("IEDLD0/MHAI1")
+            .expect("definition exists");
+
+        assert_eq!(def.name, "MHAI1");
+        match def.data_type {
+            DataType::Structure(fc_groups) => {
+                assert_eq!(fc_groups.len(), 2);
+                assert_eq!(fc_groups[0].name, "MX");
+                assert_eq!(fc_groups[1].name, "CF");
+
+                // MX group contains HA with only phsAHar
+                match &fc_groups[0].data_type {
+                    DataType::Structure(dos) => {
+                        assert_eq!(dos.len(), 1);
+                        assert_eq!(dos[0].name, "HA");
+                        match &dos[0].data_type {
+                            DataType::Structure(children) => {
+                                assert_eq!(children.len(), 1);
+                                assert_eq!(children[0].name, "phsAHar");
+                            }
+                            other => panic!("expected HA to be a structure, got {:?}", other),
+                        }
+                    }
+                    other => panic!("expected MX to be structure of DOs, got {:?}", other),
+                }
+
+                // CF group contains HA with only numHar and numCyc
+                match &fc_groups[1].data_type {
+                    DataType::Structure(dos) => {
+                        assert_eq!(dos.len(), 1);
+                        assert_eq!(dos[0].name, "HA");
+                        match &dos[0].data_type {
+                            DataType::Structure(children) => {
+                                assert_eq!(children.len(), 2);
+                                assert_eq!(children[0].name, "numHar");
+                                assert_eq!(children[1].name, "numCyc");
+                            }
+                            other => panic!("expected HA to be a structure, got {:?}", other),
+                        }
+                    }
+                    other => panic!("expected CF to be structure of DOs, got {:?}", other),
+                }
+            }
+            other => panic!("expected structure, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn model_rejects_missing_da_type_on_leaf() {
+        let json = r#"{
+            "ied_name": "IED",
+            "config": { "max_associations": 5 },
+            "logical_devices": [
+                {
+                    "inst": "LD0",
+                    "logical_nodes": [
+                        {
+                            "ln_class": "LLN0",
+                            "inst": "0",
+                            "data_objects": [
+                                {
+                                    "name": "Mod",
+                                    "children": [
+                                        { "type": "Attribute", "name": "stVal", "fc": "ST" }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        match ServerModel::from_json(json) {
+            Err(ModelLoadError::MissingAttributeType { path }) => {
+                assert!(path.ends_with(".stVal"), "unexpected path: {path}");
+            }
+            Err(other) => panic!("expected MissingAttributeType, got {other}"),
+            Ok(_) => panic!("missing da_type should fail"),
+        }
     }
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -93,10 +93,18 @@ impl Server {
         }
     }
 
-    /// Start the server with a JSON model string.
+    /// Start the server from a JSON model string.
     pub async fn run(self, model_json: String) -> Result<(), std::io::Error> {
         let model = ServerModel::from_json(&model_json)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string()))?;
+        self.run_with_model(model).await
+    }
+
+    /// Start the server with a pre-built model.
+    ///
+    /// This allows callers to initialize leaf values via [`ServerModel::value_store`]
+    /// before serving clients.
+    pub async fn run_with_model(self, model: ServerModel) -> Result<(), std::io::Error> {
         match self.inner {
             Inner::Mms(s) => s.run(model).await,
         }

--- a/src/server/server_mms_mapping.rs
+++ b/src/server/server_mms_mapping.rs
@@ -11,11 +11,19 @@ use std::time::Instant;
 use futures::{SinkExt as _, StreamExt as _};
 use mms::{
     protocol::{self, tpkt::TpktCodec, transport, ProtocolParams},
-    ConfirmedResponsePDU, ConfirmedServiceRequest, ConfirmedServiceResponse,
-    GetNameListRequestObjectScope, GetNameListResponse, Identifier, InitiateRequestPDU,
-    InitiateResponsePDU, InitiateResponsePDUInitResponseDetail, MMSpdu, Unsigned32, VisibleString,
+    AccessResult, AlternateAccess, AlternateAccessSelection, AlternateAccessSelectionSelectAccess,
+    AlternateAccessSelectionSelectAlternateAccessAccessSelection, AnonymousAlternateAccess,
+    AnonymousTypeDescriptionStructureComponents, ConfirmedResponsePDU, ConfirmedServiceRequest,
+    ConfirmedServiceResponse, Data, DataAccessError, FixedOctetString, FloatingPoint,
+    GetNameListRequestObjectScope, GetNameListResponse, GetVariableAccessAttributesRequest,
+    GetVariableAccessAttributesResponse, Identifier, InitiateRequestPDU, InitiateResponsePDU,
+    InitiateResponsePDUInitResponseDetail, Integer32, MMSString, MMSpdu, ObjectClass, ObjectName,
+    ReadResponse, TypeDescription, TypeDescriptionArray, TypeDescriptionFloatingPoint,
+    TypeDescriptionStructure, TypeDescriptionStructureComponents, TypeSpecification, Unsigned32,
+    Unsigned8, UtcTime, VisibleString,
 };
 use parking_lot::RwLock;
+use rasn::types::{BitString, OctetString};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpListener;
 use tokio::sync::Semaphore;
@@ -24,8 +32,11 @@ use tokio_util::codec::Framed;
 
 use super::server::{Association, AssociationMap, Backend, ServerTlsConfig};
 use crate::server::model::{
-    DataAttributeNode, DataObjectChild, FunctionalConstraint, LogicalDeviceNode, ServerModel,
+    DataAttributeNode, DataObjectChild, DataObjectNode, FunctionalConstraint, LogicalDeviceNode,
+    ServerModel,
 };
+use crate::server::types::DataValue;
+use crate::types::{DataDefinition, DataType};
 
 // ── MMS service vocabulary ───────────────────────────────────────────────────────────────
 
@@ -41,6 +52,17 @@ enum ServiceRequest {
         invoke_id: InvokeId,
         ld_name: String,
     },
+    GetEmptyDirectory {
+        invoke_id: InvokeId,
+    },
+    GetDataValues {
+        invoke_id: InvokeId,
+        specification: mms::VariableAccessSpecification,
+    },
+    GetDataDefinition {
+        invoke_id: InvokeId,
+        name: ObjectName,
+    },
     Unknown {
         _invoke_id: InvokeId,
     },
@@ -48,12 +70,20 @@ enum ServiceRequest {
 
 /// An IEC 61850 service response to encode and send.
 #[allow(dead_code)]
+#[derive(Debug)]
 enum ServiceResponse {
     NameList {
         invoke_id: InvokeId,
         names: Vec<String>,
     },
-    // TODO: DataValues, Success, ServiceError, …
+    DataValues {
+        invoke_id: InvokeId,
+        results: Vec<AccessResult>,
+    },
+    DataDefinition {
+        invoke_id: InvokeId,
+        response: GetVariableAccessAttributesResponse,
+    },
 }
 
 // ── MmsServer ────────────────────────────────────────────────────────────────────
@@ -190,6 +220,20 @@ fn dispatch(req: ServiceRequest, model: &ServerModel) -> Option<ServiceResponse>
                 invoke_id,
                 names: ld_directory(&model.ied_name, &model.logical_devices, &ld_name),
             })
+        }
+        ServiceRequest::GetEmptyDirectory { invoke_id } => Some(ServiceResponse::NameList {
+            invoke_id,
+            names: Vec::new(),
+        }),
+        ServiceRequest::GetDataValues {
+            invoke_id,
+            specification,
+        } => Some(ServiceResponse::DataValues {
+            invoke_id,
+            results: read_data_values(specification, model),
+        }),
+        ServiceRequest::GetDataDefinition { invoke_id, name } => {
+            Some(read_data_definition(invoke_id, name, model))
         }
         ServiceRequest::Unknown { .. } => None,
     }
@@ -354,20 +398,88 @@ impl Connection {
     }
 }
 
+/// IEC 61850 directory category derived from an MMS `GetNameList` request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DirectoryType {
+    /// `vmdSpecific` scope with `domain(9)` object class → logical devices.
+    ServerLogicalDevices,
+    /// `domainSpecific` scope with `namedVariable(0)` object class → LN contents.
+    LogicalDeviceVariables,
+    /// `namedVariableList(2)` object class → data sets (not modelled; empty list).
+    DataSets,
+    /// `journal(8)` object class → journals (not modelled; empty list).
+    Journals,
+    /// No IEC 61850 directory mapping for this class/scope combination.
+    Unsupported,
+}
+
+/// Classifies an MMS `GetNameList` request according to IEC 61850-8-1.
+///
+/// - GetServerDirectory: `vmdSpecific` scope + `domain(9)`.
+/// - GetLogicalDeviceDirectory: `domainSpecific` scope + `namedVariable(0)`.
+/// - Data sets (`namedVariableList`, 2) and journals (`journal`, 8) are valid
+///   object classes for both scopes but are not represented in the runtime
+///   model, so they yield empty directory responses.
+fn classify_directory_request(
+    object_class: &ObjectClass,
+    scope: &GetNameListRequestObjectScope,
+) -> DirectoryType {
+    match object_class {
+        ObjectClass::basicObjectClass(9)
+            if matches!(scope, GetNameListRequestObjectScope::vmdSpecific(_)) =>
+        {
+            DirectoryType::ServerLogicalDevices
+        }
+        ObjectClass::basicObjectClass(0)
+            if matches!(scope, GetNameListRequestObjectScope::domainSpecific(_)) =>
+        {
+            DirectoryType::LogicalDeviceVariables
+        }
+        ObjectClass::basicObjectClass(2) => DirectoryType::DataSets,
+        ObjectClass::basicObjectClass(8) => DirectoryType::Journals,
+        _ => DirectoryType::Unsupported,
+    }
+}
+
 fn mms_to_service(pdu: MMSpdu) -> Option<ServiceRequest> {
     match pdu {
         MMSpdu::confirmed_RequestPDU(req) => {
             let invoke_id = req.invoke_id.0;
             match req.service {
-                ConfirmedServiceRequest::getNameList(name_req) => match name_req.object_scope {
-                    GetNameListRequestObjectScope::vmdSpecific(_) => {
-                        Some(ServiceRequest::GetServerDirectory { invoke_id })
+                ConfirmedServiceRequest::getNameList(name_req) => {
+                    match classify_directory_request(&name_req.object_class, &name_req.object_scope)
+                    {
+                        DirectoryType::ServerLogicalDevices => {
+                            Some(ServiceRequest::GetServerDirectory { invoke_id })
+                        }
+                        DirectoryType::LogicalDeviceVariables => {
+                            let GetNameListRequestObjectScope::domainSpecific(id) =
+                                name_req.object_scope
+                            else {
+                                return Some(ServiceRequest::Unknown {
+                                    _invoke_id: invoke_id,
+                                });
+                            };
+                            Some(ServiceRequest::GetLogicalDeviceDirectory {
+                                invoke_id,
+                                ld_name: id.0.to_string(),
+                            })
+                        }
+                        DirectoryType::DataSets | DirectoryType::Journals => {
+                            Some(ServiceRequest::GetEmptyDirectory { invoke_id })
+                        }
+                        DirectoryType::Unsupported => Some(ServiceRequest::Unknown {
+                            _invoke_id: invoke_id,
+                        }),
                     }
-                    GetNameListRequestObjectScope::domainSpecific(id) => {
-                        Some(ServiceRequest::GetLogicalDeviceDirectory {
-                            invoke_id,
-                            ld_name: id.0.to_string(),
-                        })
+                }
+                ConfirmedServiceRequest::read(read_req) => Some(ServiceRequest::GetDataValues {
+                    invoke_id,
+                    specification: read_req.variable_access_specification,
+                }),
+                ConfirmedServiceRequest::getVariableAccessAttributes(req) => match req {
+                    GetVariableAccessAttributesRequest::name(name) => {
+                        Some(ServiceRequest::GetDataDefinition { invoke_id, name })
                     }
                     _ => Some(ServiceRequest::Unknown {
                         _invoke_id: invoke_id,
@@ -397,6 +509,23 @@ fn service_to_mms(resp: ServiceResponse) -> Option<MMSpdu> {
                 }),
             }))
         }
+        ServiceResponse::DataValues { invoke_id, results } => {
+            let read_response = ReadResponse {
+                variable_access_specification: None,
+                list_of_access_result: results.into(),
+            };
+            Some(MMSpdu::confirmed_ResponsePDU(ConfirmedResponsePDU {
+                invoke_id: Unsigned32(invoke_id),
+                service: ConfirmedServiceResponse::read(read_response),
+            }))
+        }
+        ServiceResponse::DataDefinition {
+            invoke_id,
+            response,
+        } => Some(MMSpdu::confirmed_ResponsePDU(ConfirmedResponsePDU {
+            invoke_id: Unsigned32(invoke_id),
+            service: ConfirmedServiceResponse::getVariableAccessAttributes(response),
+        })),
     }
 }
 
@@ -404,10 +533,18 @@ fn service_to_mms(resp: ServiceResponse) -> Option<MMSpdu> {
 
 /// Build the MMS GetNameList response list for a logical device.
 ///
-/// Walks the structural tree and returns one entry per leaf DA in
-/// MMS dollar-notation: `{LN}${FC}${DO}[${SDO}]*${DA}[${BDA}]*`
+/// Walks the structural tree and emits every named level in IEC 61850
+/// dollar-notation: `{LN}` and `{LN}${FC}${DO}[${SDO}]*${DA}[${BDA}]*`.
+/// Each LN, FC group, DO/SDO, structural DA and leaf DA appears as its own
+/// entry, matching the IEC 61850-7-2 GetLogicalDeviceDirectory response.
 ///
-/// Example: `LLN0$ST$Beh$stVal`, `MMXU1$MX$A$phsA$instVal$mag$f`
+/// Example:
+/// ```text
+/// LLN0
+/// LLN0$ST
+/// LLN0$ST$Beh
+/// LLN0$ST$Beh$stVal
+/// ```
 fn ld_directory(
     ied_name: &str,
     logical_devices: &[LogicalDeviceNode],
@@ -419,15 +556,21 @@ fn ld_directory(
     };
     let mut result = Vec::new();
     for ln in &ld.logical_nodes {
-        let ln_name = format!("{}{}{}", ln.prefix, ln.ln_class, ln.inst);
+        let ln_name = format!("{}{}{}", ln.ln_prefix, ln.ln_class, ln.inst);
+        result.push(ln_name.clone());
         for do_ in &ln.data_objects {
-            collect_do_paths(&ln_name, &do_.name, &do_.children, &mut result);
+            let fc = fc_for_path(do_);
+            result.push(format!("{}${}", ln_name, fc));
+            let do_path = &do_.name;
+            result.push(format!("{}${}${}", ln_name, fc, do_path));
+            collect_do_paths(&ln_name, do_path, &do_.children, &mut result);
         }
     }
     result
 }
 
-/// Walk the children of a DO or SDO, accumulating leaf DA paths.
+/// Walk the children of a DO or SDO, emitting each child path and recursing
+/// into sub-objects/structural attributes.
 fn collect_do_paths(
     ln_name: &str,
     do_path: &str,
@@ -436,16 +579,22 @@ fn collect_do_paths(
 ) {
     for child in children {
         match child {
-            DataObjectChild::Attribute(da) => collect_da_paths(ln_name, do_path, da.fc, da, result),
+            DataObjectChild::Attribute(da) => {
+                collect_da_paths(ln_name, do_path, da.fc(), da, result)
+            }
             DataObjectChild::SubObject(sdo) => {
                 let sub_path = format!("{}${}", do_path, sdo.name);
+                result.push(format!("{}${}${}", ln_name, fc_for_path(sdo), sub_path));
                 collect_do_paths(ln_name, &sub_path, &sdo.children, result);
             }
+            // Arrays are accessed through MMS alternate access and are not
+            // flattened into a plain name-list entry.
+            DataObjectChild::AttributeArray { .. } | DataObjectChild::SubObjectArray { .. } => {}
         }
     }
 }
 
-/// Walk a DA node, emitting one path entry per leaf.
+/// Walk a DA node, emitting every structural level and one entry per leaf.
 /// The FC is the functional constraint of the top-level DA ancestor and is
 /// inserted between the LN name and the DO path.
 fn collect_da_paths(
@@ -455,13 +604,326 @@ fn collect_da_paths(
     da: &DataAttributeNode,
     result: &mut Vec<String>,
 ) {
-    let da_path = format!("{}${}", parent_path, da.name);
-    if da.children.is_empty() {
-        result.push(format!("{}${}${}", ln_name, fc.as_str(), da_path));
-    } else {
-        for child in &da.children {
-            collect_da_paths(ln_name, &da_path, fc, child, result);
+    let da_path = format!("{}${}", parent_path, da.name());
+    match da {
+        DataAttributeNode::Leaf { .. } => {
+            result.push(format!("{}${}${}", ln_name, fc.as_str(), da_path));
         }
+        DataAttributeNode::Struct { children, .. } => {
+            result.push(format!("{}${}${}", ln_name, fc.as_str(), da_path));
+            for child in children {
+                collect_da_paths(ln_name, &da_path, fc, child, result);
+            }
+        }
+        // Arrays are accessed through MMS alternate access and are not
+        // flattened into a plain name-list entry.
+        DataAttributeNode::Array { .. } => {}
+    }
+}
+
+/// Returns the functional constraint used as the directory separator for a
+/// sub-object path. Sub-objects inherit the FC of their first attribute child.
+fn fc_for_path(sdo: &DataObjectNode) -> &'static str {
+    sdo.children
+        .iter()
+        .find_map(|child| match child {
+            DataObjectChild::Attribute(da) => Some(da.fc().as_str()),
+            DataObjectChild::AttributeArray { fc, .. } => Some(fc.as_str()),
+            DataObjectChild::SubObject(sdo) => Some(fc_for_path(sdo)),
+            DataObjectChild::SubObjectArray { .. } => None,
+        })
+        .unwrap_or("ST")
+}
+
+// ── GetDataValues implementation ──────────────────────────────────────────────
+
+/// A single step in an MMS alternate-access path.
+#[derive(Debug, Clone)]
+enum AccessStep {
+    Component(String),
+    Index(u32),
+}
+
+/// Resolve a GetDataValues request against the runtime value store.
+///
+/// Every `variableSpecification` in the MMS `listOfVariable` is mapped to an
+/// IEC 61850 reference and read independently. The returned vector contains
+/// one [`AccessResult`] per requested reference, preserving the order of the
+/// request. Unknown or unsupported references produce a failure access result.
+fn read_data_values(
+    specification: mms::VariableAccessSpecification,
+    model: &ServerModel,
+) -> Vec<AccessResult> {
+    let mms::VariableAccessSpecification::listOfVariable(list) = specification else {
+        return vec![AccessResult::failure(DataAccessError(9))]; // object-access-unsupported
+    };
+
+    list.0
+        .into_iter()
+        .map(|item| match mms_list_item_to_iec_reference(item) {
+            Some(reference) => match model.read_by_path(&reference) {
+                Some(value) => AccessResult::success(data_value_to_mms(&value)),
+                None => AccessResult::failure(DataAccessError(10)), // object-non-existent
+            },
+            None => AccessResult::failure(DataAccessError(9)), // object-access-unsupported
+        })
+        .collect()
+}
+
+/// Resolve a GetDataDefinition request against the runtime model.
+///
+/// The referenced object is mapped to a model path and its [`DataDefinition`]
+/// is returned as a `GetVariableAccessAttributes` response. Unknown or
+/// unsupported references return a response with an opaque `VisibleString`
+/// type so that the service completes rather than leaving the caller hanging.
+///
+/// Note: IEC 61850-8-1 encodes array indices in `GetDataValues` through MMS
+/// `AlternateAccessSpecification`, but `GetVariableAccessAttributes-Request`
+/// only carries an `ObjectName` without alternate access. Array indices must
+/// therefore be embedded in the `itemID` string (e.g. `LN$FC$DO$DA(1)`) for
+/// this server implementation to resolve them.
+fn read_data_definition(
+    invoke_id: InvokeId,
+    name: ObjectName,
+    model: &ServerModel,
+) -> ServiceResponse {
+    let definition = match mms_object_name_to_iec_reference(name, None) {
+        Some(reference) => model.get_data_definition_by_path(&reference),
+        None => None,
+    };
+
+    let definition = definition.unwrap_or_else(|| DataDefinition {
+        name: String::new(),
+        data_type: DataType::VisibleString,
+    });
+
+    ServiceResponse::DataDefinition {
+        invoke_id,
+        response: data_definition_to_get_variable_access_attributes_response(definition),
+    }
+}
+
+fn mms_list_item_to_iec_reference(
+    item: mms::AnonymousVariableAccessSpecificationListOfVariable,
+) -> Option<String> {
+    if let mms::VariableSpecification::name(name) = item.variable_specification {
+        mms_object_name_to_iec_reference(name, item.alternate_access.as_ref())
+    } else {
+        None
+    }
+}
+
+/// Converts an MMS `ObjectName` (and optional alternate access) into the
+/// internal IEC 61850 reference notation used by [`ServerModel`].
+fn mms_object_name_to_iec_reference(
+    name: ObjectName,
+    alternate_access: Option<&AlternateAccess>,
+) -> Option<String> {
+    let ObjectName::domain_specific(ds) = name else {
+        return None;
+    };
+    let domain_id = ds.domain_id.0.to_string();
+    let item_id = ds.item_id.0.to_string();
+
+    // Start with the components encoded in the MMS itemId.
+    let mut steps: Vec<AccessStep> = item_id
+        .split('$')
+        .map(|s| AccessStep::Component(s.to_string()))
+        .collect();
+
+    // Append any alternate-access steps (FC, nested components, array indices).
+    if let Some(access) = alternate_access {
+        steps.extend(flatten_alternate_access(access)?);
+    }
+
+    // The first step is the LN. References that stop at the LN level are valid
+    // for GetDataDefinition and have no FC component.
+    let ln = match steps.first()? {
+        AccessStep::Component(n) => n,
+        AccessStep::Index(_) => return None,
+    };
+
+    if steps.len() == 1 {
+        return Some(format!("{domain_id}/{ln}"));
+    }
+
+    // The second step is the FC, everything else is the path.
+    let fc = match steps.get(1)? {
+        AccessStep::Component(n) => n,
+        AccessStep::Index(_) => return None,
+    };
+
+    let mut path = String::new();
+    for step in &steps[2..] {
+        match step {
+            AccessStep::Component(name) => {
+                if !path.is_empty() {
+                    path.push('.');
+                }
+                path.push_str(name);
+            }
+            AccessStep::Index(idx) => {
+                path.push_str(&format!("({idx})"));
+            }
+        }
+    }
+
+    if path.is_empty() {
+        Some(format!("{domain_id}/{ln}[{fc}]"))
+    } else {
+        Some(format!("{domain_id}/{ln}.{path}[{fc}]"))
+    }
+}
+
+/// Convert a nested MMS `AlternateAccess` description into a flat list of
+/// component/index steps. Returns `None` for unsupported selections such as
+/// index ranges or all-elements.
+fn flatten_alternate_access(access: &AlternateAccess) -> Option<Vec<AccessStep>> {
+    let mut steps = Vec::with_capacity(access.0.len());
+    for entry in &access.0 {
+        match entry {
+            AnonymousAlternateAccess::unnamed(selection) => {
+                steps.extend(flatten_alternate_selection(selection)?);
+            }
+            AnonymousAlternateAccess::named(named) => {
+                steps.push(AccessStep::Component(named.component_name.0.to_string()));
+                steps.extend(flatten_alternate_selection(&named.access)?);
+            }
+        }
+    }
+    Some(steps)
+}
+
+fn flatten_alternate_selection(selection: &AlternateAccessSelection) -> Option<Vec<AccessStep>> {
+    match selection {
+        AlternateAccessSelection::selectAccess(sa) => Some(vec![select_access_step(sa)?]),
+        AlternateAccessSelection::selectAlternateAccess(sa) => {
+            let mut steps = vec![select_alternate_access_step(&sa.access_selection)?];
+            steps.extend(flatten_alternate_access(&sa.alternate_access)?);
+            Some(steps)
+        }
+    }
+}
+
+fn select_access_step(sa: &AlternateAccessSelectionSelectAccess) -> Option<AccessStep> {
+    match sa {
+        AlternateAccessSelectionSelectAccess::component(id) => {
+            Some(AccessStep::Component(id.0.to_string()))
+        }
+        AlternateAccessSelectionSelectAccess::index(idx) => Some(AccessStep::Index(idx.0)),
+        _ => None,
+    }
+}
+
+fn select_alternate_access_step(
+    sa: &AlternateAccessSelectionSelectAlternateAccessAccessSelection,
+) -> Option<AccessStep> {
+    match sa {
+        AlternateAccessSelectionSelectAlternateAccessAccessSelection::component(id) => {
+            Some(AccessStep::Component(id.0.to_string()))
+        }
+        AlternateAccessSelectionSelectAlternateAccessAccessSelection::index(idx) => {
+            Some(AccessStep::Index(idx.0))
+        }
+        _ => None,
+    }
+}
+
+/// Convert a server-side [`DataValue`] into an MMS [`Data`] value.
+fn data_value_to_mms(value: &DataValue) -> Data {
+    match value {
+        DataValue::Bool(b) => Data::boolean(*b),
+        DataValue::Int8(v) => Data::integer((*v).into()),
+        DataValue::Int16(v) => Data::integer((*v).into()),
+        DataValue::Int32(v) => Data::integer((*v).into()),
+        DataValue::Int64(v) => Data::integer((*v).into()),
+        DataValue::Int8u(v) => Data::unsigned((*v).into()),
+        DataValue::Int16u(v) => Data::unsigned((*v).into()),
+        DataValue::Int32u(v) => Data::unsigned((*v).into()),
+        DataValue::Float32(f) => {
+            let mut bytes = vec![0x08]; // IEEE 754 32-bit float format
+            bytes.extend_from_slice(&f.to_be_bytes());
+            Data::floating_point(FloatingPoint(OctetString::from(bytes)))
+        }
+        DataValue::OctetString(bytes) => Data::octet_string(OctetString::from(bytes.clone())),
+        DataValue::VisibleString(s) => {
+            Data::visible_string(VisibleString::try_from(s.as_str()).unwrap_or_default())
+        }
+        DataValue::UnicodeString(s) => {
+            let visible = VisibleString::try_from(s.as_str()).unwrap_or_default();
+            Data::mMSString(MMSString(visible))
+        }
+        DataValue::Quality(q) => {
+            let raw = q.to_u16().to_be_bytes();
+            Data::bit_string(BitString::from_vec(raw.to_vec()))
+        }
+        DataValue::Timestamp(ts) => {
+            let bytes = ts.to_bytes();
+            Data::utc_time(UtcTime(FixedOctetString::from(bytes)))
+        }
+        DataValue::Array(elements) => Data::array(elements.iter().map(data_value_to_mms).collect()),
+        DataValue::Struct(fields) => {
+            Data::structure(fields.iter().map(data_value_to_mms).collect())
+        }
+    }
+}
+
+/// Builds a `GetVariableAccessAttributes` response from a [`DataDefinition`].
+///
+/// Server-side IEC 61850 objects are never MMS-deletable, so `mmsDeletable`
+/// is always `false` and no address is advertised.
+fn data_definition_to_get_variable_access_attributes_response(
+    definition: DataDefinition,
+) -> GetVariableAccessAttributesResponse {
+    GetVariableAccessAttributesResponse {
+        mms_deletable: false,
+        address: None,
+        type_description: data_type_to_type_description(&definition.data_type),
+    }
+}
+
+/// Recursively maps a [`DataType`] to the equivalent MMS [`TypeDescription`].
+fn data_type_to_type_description(data_type: &DataType) -> TypeDescription {
+    match data_type {
+        DataType::Structure(children) => {
+            let components = children
+                .iter()
+                .map(|child| AnonymousTypeDescriptionStructureComponents {
+                    component_name: Some(Identifier(
+                        VisibleString::try_from(child.name.as_str()).unwrap_or_default(),
+                    )),
+                    component_type: TypeSpecification::typeDescription(Box::new(
+                        data_type_to_type_description(&child.data_type),
+                    )),
+                })
+                .collect();
+            TypeDescription::structure(TypeDescriptionStructure {
+                packed: false,
+                components: TypeDescriptionStructureComponents(components),
+            })
+        }
+        DataType::Array {
+            count,
+            element_type,
+        } => TypeDescription::array(TypeDescriptionArray {
+            packed: false,
+            number_of_elements: Unsigned32(*count),
+            element_type: TypeSpecification::typeDescription(Box::new(
+                data_type_to_type_description(element_type),
+            )),
+        }),
+        DataType::Boolean => TypeDescription::boolean(()),
+        DataType::BitString => TypeDescription::bit_string(Integer32(13)),
+        DataType::Int => TypeDescription::integer(Unsigned8(4)),
+        DataType::UInt => TypeDescription::unsigned(Unsigned8(4)),
+        DataType::Float => TypeDescription::floating_point(TypeDescriptionFloatingPoint {
+            format_width: Unsigned8(32),
+            exponent_width: Unsigned8(8),
+        }),
+        DataType::OctetString => TypeDescription::octet_string(Integer32(0)),
+        DataType::VisibleString => TypeDescription::visible_string(Integer32(255)),
+        DataType::MmsString => TypeDescription::mMSString(Integer32(255)),
+        DataType::Timestamp => TypeDescription::utc_time(()),
     }
 }
 
@@ -476,5 +938,719 @@ fn build_initiate_response(req: &InitiateRequestPDU) -> InitiateResponsePDU {
             negotiated_parameter_cbb: req.init_request_detail.proposed_parameter_cbb.clone(),
             services_supported_called: req.init_request_detail.services_supported_calling.clone(),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::server::data_value_store::DataRef;
+
+    fn domain_object_name(domain: &str, item_id: &str) -> ObjectName {
+        mms::ObjectName::domain_specific(mms::ObjectNameDomainSpecific {
+            domain_id: Identifier(VisibleString::try_from(domain).unwrap_or_default()),
+            item_id: Identifier(VisibleString::try_from(item_id).unwrap_or_default()),
+        })
+    }
+
+    fn build_alternate_access(components: &[&str]) -> AlternateAccess {
+        if components.is_empty() {
+            return AlternateAccess(Vec::new());
+        }
+
+        let mut selection = AlternateAccessSelection::selectAccess(
+            AlternateAccessSelectionSelectAccess::component(Identifier(
+                VisibleString::try_from(components[components.len() - 1]).unwrap_or_default(),
+            )),
+        );
+
+        for component in components.iter().rev().skip(1) {
+            let access_selection =
+                AlternateAccessSelectionSelectAlternateAccessAccessSelection::component(
+                    Identifier(VisibleString::try_from(*component).unwrap_or_default()),
+                );
+            selection = AlternateAccessSelection::selectAlternateAccess(
+                mms::AlternateAccessSelectionSelectAlternateAccess::new(
+                    access_selection,
+                    AlternateAccess(vec![AnonymousAlternateAccess::unnamed(selection)]),
+                ),
+            );
+        }
+        AlternateAccess(vec![AnonymousAlternateAccess::unnamed(selection)])
+    }
+
+    fn build_alternate_access_with_index(components: &[&str], index: u32) -> AlternateAccess {
+        let terminal = AlternateAccessSelection::selectAccess(
+            AlternateAccessSelectionSelectAccess::index(Unsigned32(index)),
+        );
+        let mut selection = terminal;
+        for component in components.iter().rev() {
+            let access_selection =
+                AlternateAccessSelectionSelectAlternateAccessAccessSelection::component(
+                    Identifier(VisibleString::try_from(*component).unwrap_or_default()),
+                );
+            selection = AlternateAccessSelection::selectAlternateAccess(
+                mms::AlternateAccessSelectionSelectAlternateAccess::new(
+                    access_selection,
+                    AlternateAccess(vec![AnonymousAlternateAccess::unnamed(selection)]),
+                ),
+            );
+        }
+        AlternateAccess(vec![AnonymousAlternateAccess::unnamed(selection)])
+    }
+
+    fn as_f32(data: &Data) -> f32 {
+        match data {
+            Data::floating_point(fp) => {
+                let bytes = fp.0.as_ref();
+                assert_eq!(bytes[0], 0x08, "expected 32-bit IEEE 754 tag");
+                f32::from_be_bytes([bytes[1], bytes[2], bytes[3], bytes[4]])
+            }
+            other => panic!("expected floating point, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn standard_ln_fc_do_da_reference_still_works() {
+        let model = ServerModel::from_json(
+            r#"{
+            "ied_name": "IED1",
+            "config": { "max_associations": 5 },
+            "logical_devices": [{
+                "inst": "LD0",
+                "logical_nodes": [{
+                    "ln_class": "LLN0",
+                    "inst": "",
+                    "data_objects": [{
+                        "name": "Mod",
+                        "children": [
+                            { "type": "Attribute", "name": "stVal", "fc": "ST", "da_type": "bool" }
+                        ]
+                    }]
+                }]
+            }]
+        }"#,
+        )
+        .expect("valid model");
+
+        model
+            .value_store
+            .write(
+                &DataRef::new("IED1LD0/LLN0.Mod.stVal"),
+                DataValue::Bool(true),
+            )
+            .unwrap();
+
+        let spec = mms::VariableAccessSpecification::listOfVariable(
+            mms::VariableAccessSpecificationListOfVariable(vec![
+                mms::AnonymousVariableAccessSpecificationListOfVariable::new(
+                    mms::VariableSpecification::name(domain_object_name(
+                        "IED1LD0",
+                        "LLN0$ST$Mod$stVal",
+                    )),
+                    None,
+                ),
+            ]),
+        );
+        let result = read_data_values(spec, &model);
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            matches!(&result[0], AccessResult::success(Data::boolean(true))),
+            "expected boolean true, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn multiple_variable_specifications_return_matching_access_results() {
+        let model = ServerModel::from_json(r#"{
+            "ied_name": "IED1",
+            "config": { "max_associations": 5 },
+            "logical_devices": [{
+                "inst": "LD0",
+                "logical_nodes": [{
+                    "ln_class": "LLN0",
+                    "inst": "",
+                    "data_objects": [
+                        {
+                            "name": "Mod",
+                            "children": [
+                                { "type": "Attribute", "name": "stVal", "fc": "ST", "da_type": "bool" }
+                            ]
+                        },
+                        {
+                            "name": "NamPlt",
+                            "children": [
+                                { "type": "Attribute", "name": "vendor", "fc": "DC", "da_type": "visible_string" }
+                            ]
+                        }
+                    ]
+                }]
+            }]
+        }"#)
+        .expect("valid model");
+
+        model
+            .value_store
+            .write(
+                &DataRef::new("IED1LD0/LLN0.Mod.stVal"),
+                DataValue::Bool(true),
+            )
+            .unwrap();
+        model
+            .value_store
+            .write(
+                &DataRef::new("IED1LD0/LLN0.NamPlt.vendor"),
+                DataValue::VisibleString("OpenEnergyStack".to_string()),
+            )
+            .unwrap();
+
+        let spec = mms::VariableAccessSpecification::listOfVariable(
+            mms::VariableAccessSpecificationListOfVariable(vec![
+                mms::AnonymousVariableAccessSpecificationListOfVariable::new(
+                    mms::VariableSpecification::name(domain_object_name(
+                        "IED1LD0",
+                        "LLN0$ST$Mod$stVal",
+                    )),
+                    None,
+                ),
+                mms::AnonymousVariableAccessSpecificationListOfVariable::new(
+                    mms::VariableSpecification::name(domain_object_name(
+                        "IED1LD0",
+                        "LLN0$DC$NamPlt$vendor",
+                    )),
+                    None,
+                ),
+            ]),
+        );
+        let result = read_data_values(spec, &model);
+
+        assert_eq!(result.len(), 2);
+        assert!(
+            matches!(&result[0], AccessResult::success(Data::boolean(true))),
+            "expected first result boolean true, got {:?}",
+            result
+        );
+        match &result[1] {
+            AccessResult::success(Data::visible_string(s)) => {
+                assert_eq!(s.to_string(), "OpenEnergyStack");
+            }
+            other => panic!("expected second result visible string, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn alternate_access_with_fc_do_da_resolves_leaf() {
+        let model = ServerModel::from_json(r#"{
+            "ied_name": "IED1",
+            "config": { "max_associations": 5 },
+            "logical_devices": [{
+                "inst": "LD0",
+                "logical_nodes": [{
+                    "ln_class": "LLN0",
+                    "inst": "",
+                    "data_objects": [{
+                        "name": "NamPlt",
+                        "children": [
+                            { "type": "Attribute", "name": "vendor", "fc": "DC", "da_type": "visible_string" }
+                        ]
+                    }]
+                }]
+            }]
+        }"#)
+        .expect("valid model");
+
+        model
+            .value_store
+            .write(
+                &DataRef::new("IED1LD0/LLN0.NamPlt.vendor"),
+                DataValue::VisibleString("OpenEnergyStack".to_string()),
+            )
+            .unwrap();
+
+        let access = build_alternate_access(&["DC", "NamPlt", "vendor"]);
+        let spec = mms::VariableAccessSpecification::listOfVariable(
+            mms::VariableAccessSpecificationListOfVariable(vec![
+                mms::AnonymousVariableAccessSpecificationListOfVariable::new(
+                    mms::VariableSpecification::name(domain_object_name("IED1LD0", "LLN0")),
+                    Some(access),
+                ),
+            ]),
+        );
+        let result = read_data_values(spec, &model);
+
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            AccessResult::success(Data::visible_string(s)) => {
+                assert_eq!(s.to_string(), "OpenEnergyStack");
+            }
+            other => panic!("expected visible string, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn alternate_access_array_index_selects_element() {
+        let model = ServerModel::from_json(r#"{
+            "ied_name": "IED1",
+            "config": { "max_associations": 5 },
+            "logical_devices": [{
+                "inst": "LD0",
+                "logical_nodes": [{
+                    "ln_class": "MHAI",
+                    "inst": "1",
+                    "data_objects": [{
+                        "name": "HA",
+                        "children": [
+                            { "type": "Attribute", "name": "phsAHar", "fc": "MX", "da_type": "float32" }
+                        ]
+                    }]
+                }]
+            }]
+        }"#)
+        .expect("valid model");
+
+        model
+            .value_store
+            .write(
+                &DataRef::new("IED1LD0/MHAI1.HA.phsAHar"),
+                DataValue::Array(Arc::new(vec![
+                    DataValue::Float32(1.0),
+                    DataValue::Float32(2.0),
+                    DataValue::Float32(3.0),
+                ])),
+            )
+            .unwrap();
+
+        let access = build_alternate_access_with_index(&["MX", "HA", "phsAHar"], 2);
+        let spec = mms::VariableAccessSpecification::listOfVariable(
+            mms::VariableAccessSpecificationListOfVariable(vec![
+                mms::AnonymousVariableAccessSpecificationListOfVariable::new(
+                    mms::VariableSpecification::name(domain_object_name("IED1LD0", "MHAI1")),
+                    Some(access),
+                ),
+            ]),
+        );
+        let result = read_data_values(spec, &model);
+
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            AccessResult::success(data) => assert_eq!(as_f32(data), 3.0),
+            other => panic!("expected success, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn alternate_access_structured_path_resolves_nested_leaf() {
+        let model = ServerModel::from_json(
+            r#"{
+            "ied_name": "IED1",
+            "config": { "max_associations": 5 },
+            "logical_devices": [{
+                "inst": "LD0",
+                "logical_nodes": [{
+                    "ln_class": "MMXU",
+                    "inst": "1",
+                    "data_objects": [{
+                        "name": "A",
+                        "children": [{
+                            "type": "SubObject",
+                            "name": "phsA",
+                            "children": [{
+                                "type": "Attribute",
+                                "name": "cVal",
+                                "fc": "MX",
+                                "children": [{
+                                    "name": "mag",
+                                    "fc": "MX",
+                                    "children": [
+                                        { "name": "f", "fc": "MX", "da_type": "float32" }
+                                    ]
+                                }]
+                            }]
+                        }]
+                    }]
+                }]
+            }]
+        }"#,
+        )
+        .expect("valid model");
+
+        model
+            .value_store
+            .write(
+                &DataRef::new("IED1LD0/MMXU1.A.phsA.cVal.mag.f"),
+                DataValue::Float32(50.0),
+            )
+            .unwrap();
+
+        let access = build_alternate_access(&["MX", "A", "phsA", "cVal", "mag", "f"]);
+        let spec = mms::VariableAccessSpecification::listOfVariable(
+            mms::VariableAccessSpecificationListOfVariable(vec![
+                mms::AnonymousVariableAccessSpecificationListOfVariable::new(
+                    mms::VariableSpecification::name(domain_object_name("IED1LD0", "MMXU1")),
+                    Some(access),
+                ),
+            ]),
+        );
+        let result = read_data_values(spec, &model);
+
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            AccessResult::success(data) => assert_eq!(as_f32(data), 50.0),
+            other => panic!("expected success, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unknown_reference_returns_object_non_existent() {
+        let model = ServerModel::from_json(
+            r#"{
+            "ied_name": "IED1",
+            "config": { "max_associations": 5 },
+            "logical_devices": []
+        }"#,
+        )
+        .expect("valid model");
+
+        let spec = mms::VariableAccessSpecification::listOfVariable(
+            mms::VariableAccessSpecificationListOfVariable(vec![
+                mms::AnonymousVariableAccessSpecificationListOfVariable::new(
+                    mms::VariableSpecification::name(domain_object_name(
+                        "IED1LD0",
+                        "LLN0$ST$Mod$stVal",
+                    )),
+                    None,
+                ),
+            ]),
+        );
+        let result = read_data_values(spec, &model);
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            matches!(&result[0], AccessResult::failure(DataAccessError(10))),
+            "expected object-non-existent, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn get_data_definition_resolves_leaf_type() {
+        let model = ServerModel::from_json(
+            r#"{
+            "ied_name": "IED1",
+            "config": { "max_associations": 5 },
+            "logical_devices": [{
+                "inst": "LD0",
+                "logical_nodes": [{
+                    "ln_class": "LLN0",
+                    "inst": "",
+                    "data_objects": [{
+                        "name": "Mod",
+                        "children": [
+                            { "type": "Attribute", "name": "stVal", "fc": "ST", "da_type": "bool" }
+                        ]
+                    }]
+                }]
+            }]
+        }"#,
+        )
+        .expect("valid model");
+
+        let name = domain_object_name("IED1LD0", "LLN0$ST$Mod$stVal");
+        let response = match read_data_definition(7, name, &model) {
+            ServiceResponse::DataDefinition {
+                invoke_id,
+                response,
+            } => {
+                assert_eq!(invoke_id, 7);
+                response
+            }
+            other => panic!("expected DataDefinition response, got {:?}", other),
+        };
+
+        assert!(!response.mms_deletable);
+        assert!(response.address.is_none());
+        assert!(matches!(
+            response.type_description,
+            TypeDescription::boolean(())
+        ));
+    }
+
+    #[test]
+    fn get_data_definition_resolves_structure_type() {
+        let model = ServerModel::from_json(
+            r#"{
+            "ied_name": "IED1",
+            "config": { "max_associations": 5 },
+            "logical_devices": [{
+                "inst": "LD0",
+                "logical_nodes": [{
+                    "ln_class": "MMXU",
+                    "inst": "1",
+                    "data_objects": [{
+                        "name": "A",
+                        "children": [{
+                            "type": "Attribute",
+                            "name": "phsA",
+                            "fc": "MX",
+                            "children": [{
+                                "name": "cVal",
+                                "fc": "MX",
+                                "children": [{
+                                    "name": "mag",
+                                    "fc": "MX",
+                                    "children": [
+                                        { "name": "f", "fc": "MX", "da_type": "float32" }
+                                    ]
+                                }]
+                            }]
+                        }]
+                    }]
+                }]
+            }]
+        }"#,
+        )
+        .expect("valid model");
+
+        let name = domain_object_name("IED1LD0", "MMXU1$MX$A$phsA$cVal");
+        let response = match read_data_definition(8, name, &model) {
+            ServiceResponse::DataDefinition {
+                invoke_id,
+                response,
+            } => {
+                assert_eq!(invoke_id, 8);
+                response
+            }
+            other => panic!("expected DataDefinition response, got {:?}", other),
+        };
+
+        match response.type_description {
+            TypeDescription::structure(structure) => {
+                assert_eq!(structure.components.0.len(), 1);
+                assert_eq!(
+                    structure.components.0[0]
+                        .component_name
+                        .as_ref()
+                        .map(|i| i.0.to_string()),
+                    Some("mag".to_string())
+                );
+            }
+            other => panic!("expected structure type, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn get_data_definition_resolves_logical_node() {
+        let model = ServerModel::from_json(
+            r#"{
+            "ied_name": "IED1",
+            "config": { "max_associations": 5 },
+            "logical_devices": [{
+                "inst": "LD0",
+                "logical_nodes": [{
+                    "ln_class": "LLN0",
+                    "inst": "",
+                    "data_objects": [
+                        {
+                            "name": "Mod",
+                            "children": [
+                                { "type": "Attribute", "name": "stVal", "fc": "ST", "da_type": "bool" }
+                            ]
+                        },
+                        {
+                            "name": "Beh",
+                            "children": [
+                                { "type": "Attribute", "name": "stVal", "fc": "ST", "da_type": "int32" }
+                            ]
+                        },
+                        {
+                            "name": "Health",
+                            "children": [
+                                { "type": "Attribute", "name": "stVal", "fc": "ST", "da_type": "int32" }
+                            ]
+                        },
+                        {
+                            "name": "NamPlt",
+                            "children": [
+                                { "type": "Attribute", "name": "vendor", "fc": "DC", "da_type": "visible_string" }
+                            ]
+                        }
+                    ]
+                }]
+            }]
+        }"#,
+        )
+        .expect("valid model");
+
+        let name = domain_object_name("IED1LD0", "LLN0");
+        let response = match read_data_definition(9, name, &model) {
+            ServiceResponse::DataDefinition {
+                invoke_id,
+                response,
+            } => {
+                assert_eq!(invoke_id, 9);
+                response
+            }
+            other => panic!("expected DataDefinition response, got {:?}", other),
+        };
+
+        match response.type_description {
+            TypeDescription::structure(structure) => {
+                assert_eq!(structure.components.0.len(), 2);
+
+                let st_name = structure.components.0[0]
+                    .component_name
+                    .as_ref()
+                    .map(|i| i.0.to_string());
+                assert_eq!(st_name, Some("ST".to_string()));
+
+                let dc_name = structure.components.0[1]
+                    .component_name
+                    .as_ref()
+                    .map(|i| i.0.to_string());
+                assert_eq!(dc_name, Some("DC".to_string()));
+            }
+            other => panic!("expected structure type, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn data_type_to_type_description_maps_leaf_types() {
+        assert!(matches!(
+            data_type_to_type_description(&DataType::Boolean),
+            TypeDescription::boolean(())
+        ));
+        assert!(matches!(
+            data_type_to_type_description(&DataType::Int),
+            TypeDescription::integer(Unsigned8(4))
+        ));
+        assert!(matches!(
+            data_type_to_type_description(&DataType::Float),
+            TypeDescription::floating_point(TypeDescriptionFloatingPoint {
+                format_width: Unsigned8(32),
+                exponent_width: Unsigned8(8),
+            })
+        ));
+        assert!(matches!(
+            data_type_to_type_description(&DataType::Timestamp),
+            TypeDescription::utc_time(())
+        ));
+    }
+
+    #[test]
+    fn directory_request_classification() {
+        use GetNameListRequestObjectScope::*;
+
+        assert_eq!(
+            classify_directory_request(&ObjectClass::basicObjectClass(9), &vmdSpecific(())),
+            DirectoryType::ServerLogicalDevices
+        );
+        assert_eq!(
+            classify_directory_request(
+                &ObjectClass::basicObjectClass(0),
+                &domainSpecific(Identifier(VisibleString::try_from("IED1LD0").unwrap()))
+            ),
+            DirectoryType::LogicalDeviceVariables
+        );
+        assert_eq!(
+            classify_directory_request(&ObjectClass::basicObjectClass(2), &vmdSpecific(())),
+            DirectoryType::DataSets
+        );
+        assert_eq!(
+            classify_directory_request(
+                &ObjectClass::basicObjectClass(2),
+                &domainSpecific(Identifier(VisibleString::try_from("IED1LD0").unwrap()))
+            ),
+            DirectoryType::DataSets
+        );
+        assert_eq!(
+            classify_directory_request(&ObjectClass::basicObjectClass(8), &vmdSpecific(())),
+            DirectoryType::Journals
+        );
+        assert_eq!(
+            classify_directory_request(&ObjectClass::basicObjectClass(0), &vmdSpecific(())),
+            DirectoryType::Unsupported
+        );
+        assert_eq!(
+            classify_directory_request(
+                &ObjectClass::basicObjectClass(9),
+                &domainSpecific(Identifier(VisibleString::try_from("IED1LD0").unwrap()))
+            ),
+            DirectoryType::Unsupported
+        );
+    }
+
+    #[test]
+    fn logical_device_directory_lists_full_tree() {
+        let model = ServerModel::from_json(r#"{
+            "ied_name": "DEMO",
+            "config": { "max_associations": 5 },
+            "logical_devices": [{
+                "inst": "Array",
+                "logical_nodes": [{
+                    "ln_class": "LLN0",
+                    "inst": "",
+                    "data_objects": [{
+                        "name": "Beh",
+                        "children": [
+                            { "type": "Attribute", "name": "stVal", "fc": "ST", "da_type": "bool" },
+                            { "type": "Attribute", "name": "q", "fc": "ST", "da_type": "quality" },
+                            { "type": "Attribute", "name": "t", "fc": "ST", "da_type": "timestamp" }
+                        ]
+                    }]
+                },{
+                    "prefix": "My",
+                    "ln_class": "MMXU",
+                    "inst": "1",
+                    "data_objects": [{
+                        "name": "A",
+                        "children": [{
+                            "type": "SubObject",
+                            "name": "phsA",
+                            "children": [
+                                { "type": "Attribute", "name": "cVal", "fc": "MX", "children": [
+                                    { "name": "mag", "fc": "MX", "children": [
+                                        { "name": "f", "fc": "MX", "da_type": "float32" }
+                                    ]},
+                                    { "name": "ang", "fc": "MX", "children": [
+                                        { "name": "f", "fc": "MX", "da_type": "float32" }
+                                    ]}
+                                ]},
+                                { "type": "Attribute", "name": "q", "fc": "MX", "da_type": "quality" },
+                                { "type": "Attribute", "name": "t", "fc": "MX", "da_type": "timestamp" }
+                            ]
+                        }]
+                    }]
+                }]
+            }]
+        }"#)
+        .expect("valid model");
+
+        let names = ld_directory("DEMO", &model.logical_devices, "DEMOArray");
+
+        let expected = [
+            "LLN0",
+            "LLN0$ST",
+            "LLN0$ST$Beh",
+            "LLN0$ST$Beh$stVal",
+            "LLN0$ST$Beh$q",
+            "LLN0$ST$Beh$t",
+            "MyMMXU1",
+            "MyMMXU1$MX",
+            "MyMMXU1$MX$A",
+            "MyMMXU1$MX$A$phsA",
+            "MyMMXU1$MX$A$phsA$cVal",
+            "MyMMXU1$MX$A$phsA$cVal$mag",
+            "MyMMXU1$MX$A$phsA$cVal$mag$f",
+            "MyMMXU1$MX$A$phsA$cVal$ang",
+            "MyMMXU1$MX$A$phsA$cVal$ang$f",
+            "MyMMXU1$MX$A$phsA$q",
+            "MyMMXU1$MX$A$phsA$t",
+        ];
+
+        assert_eq!(names, expected.to_vec());
     }
 }

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -1,0 +1,32 @@
+use std::sync::Arc;
+
+use crate::types::{Quality, Timestamp};
+
+/// A runtime value of an IEC 61850 DataAttribute.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DataValue {
+    Bool(bool),
+    Int8(i8),
+    Int16(i16),
+    Int32(i32),
+    Int64(i64),
+    Int8u(u8),
+    Int16u(u16),
+    Int32u(u32),
+    Float32(f32),
+    OctetString(Vec<u8>), // MmsString would need encoding
+    VisibleString(String),
+    UnicodeString(String),
+    Quality(Quality),
+    Timestamp(Timestamp),
+    /// A structured DataAttribute or a DataObject read as a collection of values.
+    Struct(Arc<Vec<DataValue>>),
+    Array(Arc<Vec<DataValue>>),
+}
+
+impl DataValue {
+    /// Returns a default placeholder for unknown initial values.
+    pub fn default_placeholder() -> Self {
+        Self::Bool(false)
+    }
+}


### PR DESCRIPTION
This PR allows to run the server with IEC 61850 client software. It holds two major steps:

1. Discoverability: a client can discover the data model structure of the server 
2. `GetDataValues`: a client can pull data from the data model

The PR needs substantial refactor as well as more tests. I want to split it into multiple commits for a cleaner history.
I did push the code for anyone who wants to play around and test.